### PR TITLE
Add training platform web service and API integration

### DIFF
--- a/docs/subcase_1b_guide.md
+++ b/docs/subcase_1b_guide.md
@@ -29,7 +29,14 @@ flowchart TD
    ```bash
    sudo subcase_1b/scripts/training_platform_start.sh --course pentest-101
    ```
-   Creates the self-paced course and prepares related scenarios.
+   Starts the Flask service, registers the instructor, and creates the course via the REST API.
+
+   To invite a learner:
+   ```bash
+   TOKEN=$(python subcase_1b/training_platform/cli.py login --username instructor --password changeme)
+   COURSE_ID=$(python subcase_1b/training_platform/cli.py list-courses --token "$TOKEN" | python -c 'import sys,json; d=json.load(sys.stdin); print(next(iter(d.keys())))')
+   python subcase_1b/training_platform/cli.py invite --token "$TOKEN" --course-id "$COURSE_ID" --email learner@example.com
+   ```
 3. **Initialize Security Pipeline**
    - Start Randomization Evaluation Platform
      ```bash
@@ -62,14 +69,14 @@ flowchart TD
    ```bash
    sudo subcase_1b/scripts/trainee_start.sh --target 10.10.0.4
    ```
-   The script employs `rustscan` instead of `nmap` to comply with the approved tool list.
+   The script employs `rustscan` instead of `nmap` to comply with the approved tool list and reports completion back to the training platform.
 4. Document discovered vulnerabilities and provide them to the instructor.
 
 ## Expected Outcomes
 
 - Course creation logs at `/var/log/training_platform/courses.log`.
 - Cyber Range initialization logs at `/var/log/cyber_range/launch.log`.
-- Trainee scan results at `/var/log/trainee/scans.log`.
+- Trainee scan results at `/var/log/trainee/scans.log` and progress stored in the training platform.
 
 ## References
 

--- a/subcase_1b/training_platform/.gitignore
+++ b/subcase_1b/training_platform/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/subcase_1b/training_platform/app.py
+++ b/subcase_1b/training_platform/app.py
@@ -1,0 +1,116 @@
+import uuid
+from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+
+# In-memory stores
+users = {}  # username -> {password, role}
+tokens = {}  # token -> username
+courses = {}  # course_id -> {title, content, instructor}
+invites = {}  # invite_code -> {course_id, email}
+progress = {}  # (course_id, username) -> progress
+
+
+def authenticate(token):
+    username = tokens.get(token)
+    if not username:
+        return None
+    return users.get(username)
+
+
+@app.route('/register', methods=['POST'])
+def register():
+    data = request.get_json(force=True)
+    username = data.get('username')
+    password = data.get('password')
+    role = data.get('role', 'trainee')
+    if not username or not password:
+        return jsonify({'error': 'username and password required'}), 400
+    if username in users:
+        return jsonify({'error': 'user exists'}), 400
+    users[username] = {'password': password, 'role': role}
+    return jsonify({'status': 'registered'})
+
+
+@app.route('/login', methods=['POST'])
+def login():
+    data = request.get_json(force=True)
+    username = data.get('username')
+    password = data.get('password')
+    user = users.get(username)
+    if not user or user['password'] != password:
+        return jsonify({'error': 'invalid credentials'}), 403
+    token = str(uuid.uuid4())
+    tokens[token] = username
+    return jsonify({'token': token})
+
+
+@app.route('/courses', methods=['POST'])
+def create_course():
+    data = request.get_json(force=True)
+    token = data.get('token')
+    user = authenticate(token)
+    if not user or user['role'] != 'instructor':
+        return jsonify({'error': 'unauthorized'}), 403
+    title = data.get('title')
+    content = data.get('content', '')
+    course_id = str(uuid.uuid4())
+    courses[course_id] = {
+        'title': title,
+        'content': content,
+        'instructor': tokens[token]
+    }
+    return jsonify({'course_id': course_id})
+
+
+@app.route('/courses', methods=['GET'])
+def list_courses():
+    token = request.args.get('token')
+    user = authenticate(token)
+    if not user:
+        return jsonify({'error': 'unauthorized'}), 403
+    return jsonify(courses)
+
+
+@app.route('/invites', methods=['POST'])
+def create_invite():
+    data = request.get_json(force=True)
+    token = data.get('token')
+    user = authenticate(token)
+    if not user or user['role'] != 'instructor':
+        return jsonify({'error': 'unauthorized'}), 403
+    course_id = data.get('course_id')
+    email = data.get('email')
+    code = str(uuid.uuid4())
+    invites[code] = {'course_id': course_id, 'email': email}
+    return jsonify({'invite_code': code})
+
+
+@app.route('/progress', methods=['POST'])
+def update_progress():
+    data = request.get_json(force=True)
+    token = data.get('token')
+    user = authenticate(token)
+    if not user:
+        return jsonify({'error': 'unauthorized'}), 403
+    course_id = data.get('course_id')
+    username = data.get('username') or tokens[token]
+    value = data.get('progress')
+    progress[(course_id, username)] = value
+    return jsonify({'status': 'updated'})
+
+
+@app.route('/progress', methods=['GET'])
+def get_progress():
+    token = request.args.get('token')
+    user = authenticate(token)
+    if not user:
+        return jsonify({'error': 'unauthorized'}), 403
+    course_id = request.args.get('course_id')
+    username = request.args.get('username') or tokens[token]
+    value = progress.get((course_id, username), 0)
+    return jsonify({'progress': value})
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/subcase_1b/training_platform/cli.py
+++ b/subcase_1b/training_platform/cli.py
@@ -1,0 +1,111 @@
+import argparse
+import json
+import sys
+from urllib import request, parse
+
+BASE_URL = 'http://localhost:5000'
+
+
+def post(path, payload):
+    data = json.dumps(payload).encode('utf-8')
+    req = request.Request(BASE_URL + path, data=data, headers={'Content-Type': 'application/json'})
+    with request.urlopen(req) as resp:
+        return json.loads(resp.read().decode('utf-8'))
+
+
+def get(path, params):
+    query = parse.urlencode(params)
+    with request.urlopen(BASE_URL + path + '?' + query) as resp:
+        return json.loads(resp.read().decode('utf-8'))
+
+
+def cmd_register(args):
+    post('/register', {'username': args.username, 'password': args.password, 'role': args.role})
+
+
+def cmd_login(args):
+    resp = post('/login', {'username': args.username, 'password': args.password})
+    print(resp.get('token', ''))
+
+
+def cmd_create_course(args):
+    post('/courses', {'token': args.token, 'title': args.title, 'content': args.content})
+
+
+def cmd_list_courses(args):
+    resp = get('/courses', {'token': args.token})
+    print(json.dumps(resp))
+
+
+def cmd_invite(args):
+    resp = post('/invites', {'token': args.token, 'course_id': args.course_id, 'email': args.email})
+    print(resp.get('invite_code', ''))
+
+
+def cmd_update_progress(args):
+    post('/progress', {'token': args.token, 'course_id': args.course_id, 'username': args.username, 'progress': args.progress})
+
+
+def cmd_get_progress(args):
+    resp = get('/progress', {'token': args.token, 'course_id': args.course_id, 'username': args.username})
+    print(resp.get('progress', 0))
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Training platform CLI')
+    sub = parser.add_subparsers(dest='cmd')
+
+    p = sub.add_parser('register')
+    p.add_argument('--username', required=True)
+    p.add_argument('--password', required=True)
+    p.add_argument('--role', choices=['instructor', 'trainee'], default='trainee')
+    p.set_defaults(func=cmd_register)
+
+    p = sub.add_parser('login')
+    p.add_argument('--username', required=True)
+    p.add_argument('--password', required=True)
+    p.set_defaults(func=cmd_login)
+
+    p = sub.add_parser('create-course')
+    p.add_argument('--token', required=True)
+    p.add_argument('--title', required=True)
+    p.add_argument('--content', default='')
+    p.set_defaults(func=cmd_create_course)
+
+    p = sub.add_parser('list-courses')
+    p.add_argument('--token', required=True)
+    p.set_defaults(func=cmd_list_courses)
+
+    p = sub.add_parser('invite')
+    p.add_argument('--token', required=True)
+    p.add_argument('--course-id', required=True)
+    p.add_argument('--email', required=True)
+    p.set_defaults(func=cmd_invite)
+
+    p = sub.add_parser('update-progress')
+    p.add_argument('--token', required=True)
+    p.add_argument('--course-id', required=True)
+    p.add_argument('--username', required=True)
+    p.add_argument('--progress', type=int, required=True)
+    p.set_defaults(func=cmd_update_progress)
+
+    p = sub.add_parser('get-progress')
+    p.add_argument('--token', required=True)
+    p.add_argument('--course-id', required=True)
+    p.add_argument('--username', required=True)
+    p.set_defaults(func=cmd_get_progress)
+
+    args = parser.parse_args()
+    if not hasattr(args, 'func'):
+        parser.print_help()
+        return 1
+    try:
+        args.func(args)
+    except Exception as exc:  # pragma: no cover - network errors
+        print(f'Error: {exc}', file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Implement Flask-based training platform with user auth, course management, invitations, and progress tracking
- Provide CLI and updated scripts to interact with the REST API
- Document workflow for instructors and trainees

## Testing
- `python -m compileall subcase_1b/training_platform`
- `bash -n subcase_1b/scripts/training_platform_start.sh`
- `bash -n subcase_1b/scripts/trainee_start.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b19b7d5fe4832d88741792016d683f