### PR TITLE
Add Docker Compose cyber range orchestration for subcase 1b

### DIFF
--- a/subcase_1b/README.md
+++ b/subcase_1b/README.md
@@ -13,3 +13,21 @@ sudo subcase_1b/scripts/trainee_start.sh --target 10.10.0.4  # run sample scan
 ```
 
 The training platform records course creation in `/var/log/training_platform/courses.log`. Trainee scan results are written to `/var/log/trainee/scans.log`, and the Cyber Range initialization log is at `/var/log/cyber_range/launch.log`.
+
+## Virtualization
+
+The cyber range is provisioned using Docker Compose. The `scripts/cyber_range_start.sh` helper launches or tears down the containerized environment:
+
+```bash
+sudo subcase_1b/scripts/cyber_range_start.sh       # start all containers
+sudo subcase_1b/scripts/cyber_range_start.sh --down # stop and remove containers
+```
+
+The accompanying `docker-compose.yml` file defines services such as a vulnerable DVWA web server, a Kali-based workstation, and the training platform.
+
+## Scenario Examples
+
+`subcase_1b/scenario.yml` includes example exercises that can be used during courses:
+
+- **dvwa_sql_injection** – explore SQL injection vulnerabilities in the DVWA service on port 8000.
+- **weak_ssh_credentials** – practice brute-force attacks against weak SSH passwords on the trainee workstation.

--- a/subcase_1b/docker-compose.yml
+++ b/subcase_1b/docker-compose.yml
@@ -1,0 +1,24 @@
+---
+version: '3.8'
+services:
+  training_platform:
+    image: nginx:alpine
+    container_name: training_platform
+    networks:
+      - cyber_range
+  trainee_workstation:
+    image: kalilinux/kali-rolling
+    container_name: trainee_workstation
+    command: ["tail", "-f", "/dev/null"]
+    networks:
+      - cyber_range
+  vuln_web:
+    image: vulnerables/web-owasp-dvwa
+    container_name: vuln_web
+    ports:
+      - "8000:80"
+    networks:
+      - cyber_range
+networks:
+  cyber_range:
+    driver: bridge

--- a/subcase_1b/scenario.yml
+++ b/subcase_1b/scenario.yml
@@ -101,3 +101,18 @@ links:
   - [bips, ng_siem]
   - [ng_siem, cicms]
   - [cicms, ng_soc]
+scenarios:
+  - id: "dvwa_sql_injection"
+    title: "DVWA SQL Injection Lab"
+    description: >
+      Exploit SQL injection vulnerabilities in the DVWA service exposed on
+      port 8000.
+    services:
+      - "vuln_web"
+      - "trainee_workstation"
+  - id: "weak_ssh_credentials"
+    title: "Weak SSH Credentials Lab"
+    description: >
+      Brute-force weak SSH passwords on the trainee workstation container.
+    services:
+      - "trainee_workstation"

--- a/subcase_1b/scripts/cyber_range_start.sh
+++ b/subcase_1b/scripts/cyber_range_start.sh
@@ -3,10 +3,44 @@ set -euo pipefail
 
 RANGE_LOG="${RANGE_LOG:-/var/log/cyber_range/launch.log}"
 VULN_PROFILE="${VULN_PROFILE:-baseline}"
+COMPOSE_FILE="$(dirname "$0")/../docker-compose.yml"
 
-initialize_range() {
-    mkdir -p "$(dirname "$RANGE_LOG")"
-    echo "$(date) Cyber Range initialized with profile $VULN_PROFILE" >> "$RANGE_LOG"
+usage() {
+    echo "Usage: $0 [--down]"
+    echo "Deploy or tear down the cyber range environment using Docker Compose."
 }
 
-initialize_range
+log() {
+    mkdir -p "$(dirname "$RANGE_LOG")"
+    echo "$(date) $1" >> "$RANGE_LOG"
+}
+
+deploy() {
+    log "Launching cyber range with profile $VULN_PROFILE"
+    if command -v docker >/dev/null 2>&1; then
+        docker compose -f "$COMPOSE_FILE" up -d
+    else
+        log "docker command not found; skipping container launch"
+    fi
+}
+
+teardown() {
+    log "Stopping cyber range"
+    if command -v docker >/dev/null 2>&1; then
+        docker compose -f "$COMPOSE_FILE" down
+    else
+        log "docker command not found; nothing to stop"
+    fi
+}
+
+case "${1:-up}" in
+    --down|down)
+        teardown
+        ;;
+    --help|-h)
+        usage
+        ;;
+    *)
+        deploy
+        ;;
+ esac


### PR DESCRIPTION
## Summary
- add docker-compose setup with DVWA, Kali workstation, and training platform
- orchestrate containers via updated `cyber_range_start.sh`
- document virtualization workflow and example scenarios

## Testing
- `bash -n subcase_1b/scripts/cyber_range_start.sh`
- `yamllint subcase_1b/scenario.yml subcase_1b/docker-compose.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b19c833aa8832d99f450f9f3475de1