### PR TITLE
Integrate Suricata IDS and ML analysis for subcase 1c

### DIFF
--- a/docs/subcase_1c_guide.md
+++ b/docs/subcase_1c_guide.md
@@ -10,6 +10,8 @@ Simulate benign malware activity and integrate threat intelligence feeds to exer
    sudo subcase_1c/scripts/start_soc_services.sh
    ```
    Launches BIPS, NG-SIEM, CICMS, and NG-SOC.
+   BIPS now includes a Suricata IDS with a lightweight ML classifier that
+   processes alerts and enriches rules using indicators from the MISP feed.
    Port checks rely on Bash's `/dev/tcp` and `timeout` rather than `netcat`.
 
 2. **Start CTI component and ingest feeds**
@@ -51,6 +53,7 @@ Simulate benign malware activity and integrate threat intelligence feeds to exer
 
 - [`start_soc_services.sh`](../subcase_1c/scripts/start_soc_services.sh)
 - [`start_cti_component.sh`](../subcase_1c/scripts/start_cti_component.sh)
+- [`bips_start.sh`](../subcase_1c/scripts/bips_start.sh)
 - [`fetch-cti-feed.service`](../subcase_1c/ansible/roles/misp/templates/fetch-cti-feed.service.j2)
 - [`start_c2_server.sh`](../subcase_1c/scripts/start_c2_server.sh)
 - [`benign_malware_simulator.ps1`](../subcase_1c/scripts/benign_malware_simulator.ps1)

--- a/subcase_1c/ansible/roles/bips/defaults/main.yml
+++ b/subcase_1c/ansible/roles/bips/defaults/main.yml
@@ -2,3 +2,4 @@
 # Base URL for NG-SOC package repository. Override in inventory or group vars.
 ngsoc_repo_url: "https://packages.internal.example.com"
 bips_agent_checksum: "sha256:6c85a96bf3dc07d5dc4186d49ea6ab77f06e082d4c88b8221ebfbd820c2af78e"
+suricata_rules_url: "https://rules.emergingthreats.net/open/suricata/emerging.rules.tar.gz"

--- a/subcase_1c/ansible/roles/bips/tasks/main.yml
+++ b/subcase_1c/ansible/roles/bips/tasks/main.yml
@@ -12,6 +12,41 @@
     state: present
   become: yes
 
+- name: Install Suricata IDS
+  ansible.builtin.apt:
+    name: suricata
+    state: present
+  become: yes
+
+- name: Install ML dependencies
+  ansible.builtin.apt:
+    name:
+      - python3-sklearn
+      - python3-requests
+    state: present
+  become: yes
+
+- name: Download Suricata ruleset
+  ansible.builtin.get_url:
+    url: "{{ suricata_rules_url }}"
+    dest: "/tmp/suricata-rules.tar.gz"
+    mode: "0644"
+  become: yes
+
+- name: Extract Suricata rules
+  ansible.builtin.unarchive:
+    src: "/tmp/suricata-rules.tar.gz"
+    dest: "/etc/suricata/rules"
+    remote_src: yes
+  become: yes
+
+- name: Enable and start Suricata
+  ansible.builtin.service:
+    name: suricata
+    state: started
+    enabled: yes
+  become: yes
+
 - name: Configure BIPS
   ansible.builtin.template:
     src: bips.conf.j2

--- a/subcase_1c/bips/__init__.py
+++ b/subcase_1c/bips/__init__.py
@@ -1,0 +1,1 @@
+"""BIPS extension with IDS alert analysis and ML classification."""

--- a/subcase_1c/bips/ids_ml.py
+++ b/subcase_1c/bips/ids_ml.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Simple IDS alert processor with ML classification and MISP enrichment.
+
+This module parses Suricata EVE JSON alerts, applies a scikit-learn model to
+classify each event as benign or malicious, and updates Suricata rules using a
+MISP threat intelligence feed.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable, List
+
+import joblib
+import requests
+from sklearn.feature_extraction.text import CountVectorizer
+from sklearn.naive_bayes import MultinomialNB
+
+MODEL_FILE = Path(__file__).with_name("model.joblib")
+DEFAULT_ALERT_FILE = Path("/var/log/suricata/eve.json")
+DEFAULT_RULE_FILE = Path("/etc/suricata/rules/misp.rules")
+
+
+def train_model() -> None:
+    """Train a trivial text classifier and persist it."""
+    samples = [
+        "Exploit attempt detected",
+        "Known malicious IP",
+        "Normal HTTP traffic",
+        "Benign DNS query",
+    ]
+    labels = [1, 1, 0, 0]  # 1 = malicious, 0 = benign
+    vectorizer = CountVectorizer()
+    features = vectorizer.fit_transform(samples)
+    model = MultinomialNB().fit(features, labels)
+    joblib.dump((vectorizer, model), MODEL_FILE)
+
+
+def load_model():
+    """Load the classifier, training it first if necessary."""
+    if not MODEL_FILE.exists():
+        train_model()
+    return joblib.load(MODEL_FILE)
+
+
+def classify_event(event: dict) -> int:
+    """Classify a single Suricata alert event."""
+    vectorizer, model = load_model()
+    text = event.get("alert", {}).get("signature", "")
+    features = vectorizer.transform([text])
+    return int(model.predict(features)[0])
+
+
+def process_alerts(path: Path) -> List[dict]:
+    """Process alerts from the given EVE JSON file."""
+    results = []
+    if not path.exists():
+        return results
+    with path.open() as handle:
+        for line in handle:
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            label = classify_event(event)
+            results.append({"event": event, "label": label})
+    return results
+
+
+def fetch_misp_iocs(url: str) -> Iterable[str]:
+    """Fetch indicators from a MISP JSON feed endpoint."""
+    try:
+        response = requests.get(url, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+    except Exception:
+        return []
+    return data.get("iocs", [])
+
+
+def update_rules_from_misp(url: str, rules_file: Path) -> None:
+    """Append MISP IOCs to a Suricata rules file."""
+    iocs = fetch_misp_iocs(url)
+    if not iocs:
+        return
+    rules_file.parent.mkdir(parents=True, exist_ok=True)
+    with rules_file.open("a") as handle:
+        for idx, ioc in enumerate(iocs, start=1):
+            rule = (
+                f"alert ip {ioc} any -> any any "
+                f"(msg:\"MISP IOC {ioc}\"; sid:100000{idx}; rev:1;)\n"
+            )
+            handle.write(rule)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Process IDS alerts with ML")
+    parser.add_argument("--alert-file", type=Path, default=DEFAULT_ALERT_FILE)
+    parser.add_argument("--misp-url", default="http://localhost:8443/feed.json")
+    parser.add_argument(
+        "--update-rules",
+        action="store_true",
+        help="Fetch MISP feed and append indicators to Suricata rules",
+    )
+    args = parser.parse_args()
+
+    if args.update_rules:
+        update_rules_from_misp(args.misp_url, DEFAULT_RULE_FILE)
+
+    results = process_alerts(args.alert_file)
+    for res in results:
+        print(json.dumps(res))
+
+
+if __name__ == "__main__":
+    main()

--- a/subcase_1c/scripts/bips_start.sh
+++ b/subcase_1c/scripts/bips_start.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+LOG_FILE="${LOG_FILE:-/var/log/bips/start.log}"
+IDS_ML_DIR="$(cd "$(dirname "$0")/.." && pwd)/bips"
+ML_SCRIPT="$IDS_ML_DIR/ids_ml.py"
+
+start_bips() {
+    mkdir -p "$(dirname "$LOG_FILE")"
+    echo "$(date) Starting Suricata service" >> "$LOG_FILE"
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl start suricata || true
+    fi
+    echo "$(date) Launching BIPS ML processor" >> "$LOG_FILE"
+    python3 "$ML_SCRIPT" --update-rules &>> "$LOG_FILE" &
+}
+
+start_bips


### PR DESCRIPTION
## Summary
- Install Suricata IDS with initial rules and required ML dependencies via Ansible.
- Add Python module to process IDS alerts, classify events using scikit-learn, and enrich rules from a MISP CTI feed.
- Introduce startup script that launches Suricata and the ML processor.
- Document new IDS/ML and CTI capabilities for subcase 1c.

## Testing
- `python -m py_compile subcase_1c/bips/*.py`
- `bash -n subcase_1c/scripts/bips_start.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b19ed1f034832db485861bdcfd6c86