### PR TITLE
Add post-incident reporting utilities

### DIFF
--- a/docs/post_incident_process.md
+++ b/docs/post_incident_process.md
@@ -1,0 +1,18 @@
+# Post-Incident Process
+
+This document describes the steps to handle the post-incident report generated for Subcase 1c.
+
+## Review the Report
+1. Execute `subcase_1c/scripts/generate_post_incident_report.sh` after the incident ends.
+2. Locate the timestamped file in the `reports/` directory.
+3. Examine the NG‑SIEM, BIPS and Act sections to understand the event timeline and impacts.
+
+## Apply Patches
+1. Identify required fixes based on findings in the report.
+2. Apply patches to affected systems, validating them in a staging environment first.
+3. Record applied patches and verification steps.
+
+## Update Scenario Infrastructure
+1. Update playbooks, configurations or images to include the patches.
+2. Rebuild or redeploy the lab to ensure changes take effect.
+3. Commit infrastructure updates and note them for future iterations.

--- a/docs/training_workflows.md
+++ b/docs/training_workflows.md
@@ -41,3 +41,7 @@ Trainees should familiarize themselves with fundamental concepts in network secu
 5. **Final Evaluation** – Review submitted reports and platform evaluation results. *Validation:* each trainee’s submission status is recorded in the grading dashboard. *Artifacts:* completed grading rubric and evaluation summaries.
 
 These workflows ensure that trainees gain practical experience while instructors maintain oversight within the simulated environment.
+
+## Post-Incident Reporting and Iteration
+
+Run `subcase_1c/scripts/generate_post_incident_report.sh` once evaluations are complete to gather NG‑SIEM, BIPS and Act logs. Review the resulting file in `reports/` following the guidance in `docs/post_incident_process.md` and update playbooks or teaching materials accordingly before the next training cycle.

--- a/subcase_1c/feedback_form.md
+++ b/subcase_1c/feedback_form.md
@@ -1,0 +1,9 @@
+# Subcase 1c Feedback Form
+
+Please fill out this form after completing the scenario.
+
+- **Name (optional):**
+- **Date:**
+- **What worked well?**
+- **What could be improved?**
+- **Additional comments:**

--- a/subcase_1c/scripts/generate_post_incident_report.sh
+++ b/subcase_1c/scripts/generate_post_incident_report.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+
+# Determine repository root
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+REPORT_DIR="$REPO_ROOT/reports"
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+REPORT_FILE="$REPORT_DIR/post_incident_report_$TIMESTAMP.txt"
+
+# Default log locations (can be overridden by environment variables)
+NG_SIEM_LOG=${NG_SIEM_LOG:-/var/log/ngsiem.log}
+BIPS_LOG=${BIPS_LOG:-/var/log/bips.log}
+ACT_LOG=${ACT_LOG:-/var/log/act.log}
+
+mkdir -p "$REPORT_DIR"
+
+{
+  echo "Post-Incident Report - $TIMESTAMP"
+  echo "================================"
+
+  collect_log() {
+    local name="$1"; local path="$2"
+    echo ""
+    if [[ -f "$path" ]]; then
+      echo "=== $name Logs ($path) ==="
+      tail -n 100 "$path"
+    else
+      echo "=== $name Logs not found at $path ==="
+    fi
+  }
+
+  collect_log "NG-SIEM" "$NG_SIEM_LOG"
+  collect_log "BIPS" "$BIPS_LOG"
+  collect_log "Act" "$ACT_LOG"
+} > "$REPORT_FILE"
+
+echo "Report generated at $REPORT_FILE"


### PR DESCRIPTION
## Summary
- add script to gather NG-SIEM, BIPS and Act logs into timestamped post-incident reports
- document report review, patching and infrastructure update process
- update training workflow guidance and add feedback form

## Testing
- `bash -n subcase_1c/scripts/generate_post_incident_report.sh`
- `subcase_1c/scripts/generate_post_incident_report.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b1a7ce7db0832d9872a378a603990e