### PR TITLE
Add malware detection scanner with YARA and ClamAV

### DIFF
--- a/subcase_1c/malware_detection/__init__.py
+++ b/subcase_1c/malware_detection/__init__.py
@@ -1,0 +1,1 @@
+"""Malware detection package for scanning files with YARA and ClamAV."""

--- a/subcase_1c/malware_detection/rules/example.yar
+++ b/subcase_1c/malware_detection/rules/example.yar
@@ -1,0 +1,6 @@
+rule MALWARE_TEST {
+    strings:
+        $a = "MALWARE_TEST"
+    condition:
+        $a
+}

--- a/subcase_1c/malware_detection/scanner.py
+++ b/subcase_1c/malware_detection/scanner.py
@@ -1,0 +1,55 @@
+"""Utilities for scanning files using YARA rules and ClamAV."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Dict, List
+
+import yara
+
+
+class MalwareScanner:
+    """Scan files for malicious content using YARA and ClamAV."""
+
+    def __init__(self, rules_path: Path) -> None:
+        """Compile YARA rules from the provided path."""
+        self.rules = yara.compile(filepath=str(rules_path))
+
+    def scan_with_yara(self, file_path: Path) -> List[str]:
+        """Return a list of matched YARA rule names."""
+        matches = self.rules.match(str(file_path))
+        return [match.rule for match in matches]
+
+    def scan_with_clamav(self, file_path: Path) -> str:
+        """Run ClamAV (clamscan) on the file and return the result string."""
+        try:
+            proc = subprocess.run(
+                ["clamscan", "--no-summary", str(file_path)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except FileNotFoundError:
+            return "clamscan not found"
+
+        if proc.returncode == 0:
+            return "OK"
+        if proc.returncode == 1:
+            return proc.stdout.strip()
+        return f"ERROR: {proc.stderr.strip()}"
+
+    def scan(self, file_path: Path) -> Dict[str, object]:
+        """Scan a file with YARA and ClamAV returning a report dictionary."""
+        return {
+            "file": str(file_path),
+            "yara_matches": self.scan_with_yara(file_path),
+            "clamav": self.scan_with_clamav(file_path),
+        }
+
+    def generate_report(self, file_path: Path, report_path: Path) -> Dict[str, object]:
+        """Generate a JSON report for the scan results."""
+        results = self.scan(file_path)
+        report_path.write_text(json.dumps(results, indent=2))
+        return results

--- a/subcase_1c/malware_detection/tests/data/benign.txt
+++ b/subcase_1c/malware_detection/tests/data/benign.txt
@@ -1,0 +1,1 @@
+This is a harmless file.

--- a/subcase_1c/malware_detection/tests/data/malicious.txt
+++ b/subcase_1c/malware_detection/tests/data/malicious.txt
@@ -1,0 +1,1 @@
+This file contains MALWARE_TEST string.

--- a/subcase_1c/malware_detection/tests/test_scanner.py
+++ b/subcase_1c/malware_detection/tests/test_scanner.py
@@ -1,0 +1,43 @@
+import json
+from pathlib import Path
+import sys
+import unittest
+from unittest import mock
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from malware_detection.scanner import MalwareScanner
+
+
+class ScannerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        base = Path(__file__).resolve().parent
+        cls.data_dir = base / "data"
+        rules_path = base.parent / "rules" / "example.yar"
+        cls.scanner = MalwareScanner(rules_path)
+        cls.benign = cls.data_dir / "benign.txt"
+        cls.malicious = cls.data_dir / "malicious.txt"
+
+    def test_yara_benign(self):
+        self.assertEqual(self.scanner.scan_with_yara(self.benign), [])
+
+    def test_yara_malicious(self):
+        self.assertEqual(self.scanner.scan_with_yara(self.malicious), ["MALWARE_TEST"])
+
+    def test_clamav_parsing(self):
+        fake = mock.Mock(returncode=1, stdout="malicious.txt: Eicar-Test-Signature FOUND\n", stderr="")
+        with mock.patch("subprocess.run", return_value=fake):
+            result = self.scanner.scan_with_clamav(self.malicious)
+        self.assertIn("FOUND", result)
+
+    def test_generate_report(self):
+        report_file = self.data_dir / "report.json"
+        result = self.scanner.generate_report(self.malicious, report_file)
+        self.assertTrue(report_file.exists())
+        loaded = json.loads(report_file.read_text())
+        self.assertEqual(result, loaded)
+        report_file.unlink()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add malware detection package with YARA rule compilation and optional ClamAV scanning
- include sample YARA rule and JSON reporting
- add unit tests for benign and malicious samples

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b551041664832d8f7f546883cc5fb4