### PR TITLE
Add SOC alerting service with configurable notifier

### DIFF
--- a/soc_alerts/notifier.py
+++ b/soc_alerts/notifier.py
@@ -1,0 +1,60 @@
+"""Notification utilities for SOC alerts."""
+
+from __future__ import annotations
+
+import logging
+import smtplib
+from email.mime.text import MIMEText
+from logging.handlers import SysLogHandler
+from typing import Dict, Tuple
+
+import requests
+
+
+class Notifier:
+    """Send alerts using email, syslog, or webhook."""
+
+    def __init__(self, config: Dict[str, object]) -> None:
+        self.config = config
+
+    def send(self, message: str) -> None:
+        method = self.config.get("method")
+        if method == "email":
+            self._send_email(message)
+        elif method == "syslog":
+            self._send_syslog(message)
+        elif method == "webhook":
+            self._send_webhook(message)
+        else:
+            raise ValueError(f"Unsupported method: {method}")
+
+    # ------------------------------------------------------------------
+    # Individual implementations
+    def _send_email(self, message: str) -> None:
+        smtp_server = self.config.get("smtp_server", "localhost")
+        smtp_port = int(self.config.get("smtp_port", 25))
+        from_addr = self.config.get("from", "alerts@example.com")
+        to_addr = self.config.get("to")
+        mime = MIMEText(message)
+        mime["Subject"] = self.config.get("subject", "SOC Alert")
+        mime["From"] = from_addr
+        mime["To"] = to_addr
+        with smtplib.SMTP(smtp_server, smtp_port) as server:
+            server.sendmail(from_addr, [to_addr], mime.as_string())
+
+    def _send_syslog(self, message: str) -> None:
+        address: Tuple[str, int] = self.config.get("address", ("localhost", 514))
+        logger = logging.getLogger("soc_alerts")
+        logger.setLevel(logging.INFO)
+        handler = SysLogHandler(address=address)
+        logger.addHandler(handler)
+        try:
+            logger.info(message)
+        finally:
+            logger.removeHandler(handler)
+            handler.close()
+
+    def _send_webhook(self, message: str) -> None:
+        url = self.config.get("url")
+        headers = {"Content-Type": "application/json"}
+        requests.post(url, json={"alert": message}, headers=headers, timeout=5)

--- a/soc_alerts/service.py
+++ b/soc_alerts/service.py
@@ -1,0 +1,30 @@
+"""Simple event listener to trigger alerts from SOC components."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict
+
+from .notifier import Notifier
+
+
+class AlertService:
+    """Listen for events and send contextual alerts."""
+
+    def __init__(self, notifier: Notifier) -> None:
+        self.notifier = notifier
+
+    def handle_event(self, source: str, event_type: str, host: str) -> Dict[str, str]:
+        """Process an event and dispatch an alert."""
+        event = {
+            "source": source,
+            "type": event_type,
+            "host": host,
+            "timestamp": datetime.utcnow().isoformat(),
+        }
+        message = (
+            f"[{event['timestamp']}] {event['source']} detected "
+            f"{event['type']} on {event['host']}"
+        )
+        self.notifier.send(message)
+        return event

--- a/soc_alerts/tests/test_service.py
+++ b/soc_alerts/tests/test_service.py
@@ -1,0 +1,85 @@
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from soc_alerts.notifier import Notifier
+from soc_alerts.service import AlertService
+
+
+def test_email_notification(monkeypatch):
+    sent = {}
+
+    class DummySMTP:
+        def __init__(self, host, port):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def sendmail(self, from_addr, to_addrs, msg):
+            sent["from"] = from_addr
+            sent["to"] = to_addrs
+            sent["msg"] = msg
+
+    monkeypatch.setattr("smtplib.SMTP", DummySMTP)
+
+    notifier = Notifier({"method": "email", "to": "dest@example.com"})
+    service = AlertService(notifier)
+    service.handle_event("malware_detection", "malware", "host1")
+
+    assert sent["to"] == ["dest@example.com"]
+    assert "malware" in sent["msg"]
+
+
+def test_syslog_notification(monkeypatch):
+    messages = []
+
+    def fake_emit(self, record):
+        messages.append(self.format(record))
+
+    monkeypatch.setattr("logging.handlers.SysLogHandler.emit", fake_emit)
+
+    notifier = Notifier({"method": "syslog"})
+    service = AlertService(notifier)
+    service.handle_event("bips", "intrusion", "host2")
+
+    assert any("intrusion" in m for m in messages)
+
+
+def test_webhook_notification():
+    received = {}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(length)
+            received["data"] = json.loads(body.decode())
+            self.send_response(200)
+            self.end_headers()
+
+        def log_message(self, format, *args):  # noqa: A003
+            return
+
+    server = HTTPServer(("localhost", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    url = f"http://localhost:{server.server_port}/"
+    notifier = Notifier({"method": "webhook", "url": url})
+    service = AlertService(notifier)
+    service.handle_event("malware_detection", "malware", "host3")
+
+    server.shutdown()
+    thread.join()
+
+    assert received["data"]["alert"].startswith("[")
+    assert "malware_detection" in received["data"]["alert"]
+

--- a/subcase_1c/scenario.yml
+++ b/subcase_1c/scenario.yml
@@ -59,3 +59,10 @@ links:
   - [infected_host, c2_server]
   - [infected_host, soc_server]
   - [soc_server, cti_component]
+alerts:
+  - source: malware_detection
+    notify: email
+    description: "Notify SOC when malware is detected"
+  - source: bips
+    notify: syslog
+    description: "Notify SOC on intrusion detection"


### PR DESCRIPTION
## Summary
- add `soc_alerts` package for alert notifications via email, syslog or webhook
- implement `AlertService` to listen for malware_detection and BIPS events
- demonstrate alert rules in `subcase_1c/scenario.yml`
- cover notifier functions with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b551cf9024832db485f71f7da4031d