### PR TITLE
Improve post-incident reporting workflow

### DIFF
--- a/docs/post_incident_process.md
+++ b/docs/post_incident_process.md
@@ -16,3 +16,34 @@ This document describes the steps to handle the post-incident report generated f
 1. Update playbooks, configurations or images to include the patches.
 2. Rebuild or redeploy the lab to ensure changes take effect.
 3. Commit infrastructure updates and note them for future iterations.
+
+## Sample Report
+The generated report contains sections for input vectors, lateral movement and mitigation times, followed by findings, containment actions and recommendations. A trimmed example is shown below:
+
+```markdown
+# Post-Incident Report - SAMPLE
+
+## Summary
+### Input Vectors
+No relevant entries found.
+
+### Lateral Movements
+No relevant entries found.
+
+### Mitigation Times
+No relevant entries found.
+
+## Findings
+- Placeholder finding.
+
+## Containment Actions
+- Placeholder action.
+
+## Recommendations
+- Placeholder recommendation.
+```
+
+## Instructor Guidance
+- Review the **Summary** to ensure trainees identified the initial vector, any lateral movement and how quickly mitigation occurred.
+- Discuss the **Findings** and **Containment Actions** with trainees to validate their response steps.
+- Use the **Recommendations** section to drive improvements for future iterations of the scenario.

--- a/reports/post_incident_report_sample.html
+++ b/reports/post_incident_report_sample.html
@@ -1,0 +1,16 @@
+<html><body>
+<h1>Post-Incident Report - SAMPLE</h1>
+<h2>Summary</h2>
+<h3>Input Vectors</h3>
+<p>No relevant entries found.</p>
+<h3>Lateral Movements</h3>
+<p>No relevant entries found.</p>
+<h3>Mitigation Times</h3>
+<p>No relevant entries found.</p>
+<h2>Findings</h2>
+<ul><li>Placeholder finding.</li></ul>
+<h2>Containment Actions</h2>
+<ul><li>Placeholder action.</li></ul>
+<h2>Recommendations</h2>
+<ul><li>Placeholder recommendation.</li></ul>
+</body></html>

--- a/reports/post_incident_report_sample.md
+++ b/reports/post_incident_report_sample.md
@@ -1,0 +1,20 @@
+# Post-Incident Report - SAMPLE
+
+## Summary
+### Input Vectors
+No relevant entries found.
+
+### Lateral Movements
+No relevant entries found.
+
+### Mitigation Times
+No relevant entries found.
+
+## Findings
+- Placeholder finding.
+
+## Containment Actions
+- Placeholder action.
+
+## Recommendations
+- Placeholder recommendation.

--- a/subcase_1c/scripts/generate_post_incident_report.sh
+++ b/subcase_1c/scripts/generate_post_incident_report.sh
@@ -4,8 +4,9 @@ set -euo pipefail
 # Determine repository root
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 REPORT_DIR="$REPO_ROOT/reports"
-TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
-REPORT_FILE="$REPORT_DIR/post_incident_report_$TIMESTAMP.txt"
+TIMESTAMP="${TIMESTAMP_OVERRIDE:-$(date +%Y%m%d_%H%M%S)}"
+REPORT_MD="$REPORT_DIR/post_incident_report_$TIMESTAMP.md"
+REPORT_HTML="$REPORT_DIR/post_incident_report_$TIMESTAMP.html"
 
 # Default log locations (can be overridden by environment variables)
 NG_SIEM_LOG=${NG_SIEM_LOG:-/var/log/ngsiem.log}
@@ -14,24 +15,87 @@ ACT_LOG=${ACT_LOG:-/var/log/act.log}
 
 mkdir -p "$REPORT_DIR"
 
-{
-  echo "Post-Incident Report - $TIMESTAMP"
-  echo "================================"
-
-  collect_log() {
-    local name="$1"; local path="$2"
-    echo ""
-    if [[ -f "$path" ]]; then
-      echo "=== $name Logs ($path) ==="
-      tail -n 100 "$path"
+# Extract lines matching a pattern from a log file
+extract_info() {
+  local label="$1"; local log="$2"; local pattern="$3"
+  echo "### $label"
+  if [[ -f "$log" ]]; then
+    local matches
+    matches=$(grep -iE "$pattern" "$log" || true)
+    if [[ -n "$matches" ]]; then
+      echo "$matches"
     else
-      echo "=== $name Logs not found at $path ==="
+      echo "No relevant entries found."
     fi
+  else
+    echo "Log file $log not found."
+  fi
+  echo ""
+}
+
+# Convert a log into a Markdown code block
+collect_log() {
+  local name="$1"; local path="$2"
+  echo "### $name Logs ($path)"
+  if [[ -f "$path" ]]; then
+    echo '```'
+    tail -n 100 "$path"
+    echo '```'
+  else
+    echo "_Logs not found at $path._"
+  fi
+  echo ""
+}
+
+{
+  echo "# Post-Incident Report - $TIMESTAMP"
+  echo ""
+  echo "## Summary"
+  extract_info "Input Vectors" "$NG_SIEM_LOG" "vector|entry"
+  extract_info "Lateral Movements" "$ACT_LOG" "lateral"
+  extract_info "Mitigation Times" "$BIPS_LOG" "mitigat|patch|contain"
+
+  section_list() {
+    local title="$1"; local log="$2"; local pattern="$3"
+    echo "## $title"
+    if [[ -f "$log" ]]; then
+      local matches
+      matches=$(grep -iE "$pattern" "$log" || true)
+      if [[ -n "$matches" ]]; then
+        echo "$matches" | sed 's/^/- /'
+      else
+        echo "- None found."
+      fi
+    else
+      echo "- Log file $log not found."
+    fi
+    echo ""
   }
 
+  section_list "Findings" "$NG_SIEM_LOG" "FINDING|ALERT"
+  section_list "Containment Actions" "$ACT_LOG" "contain|mitigat|block"
+  section_list "Recommendations" "$BIPS_LOG" "recommend|advice|patch"
+
+  echo "## Logs"
   collect_log "NG-SIEM" "$NG_SIEM_LOG"
   collect_log "BIPS" "$BIPS_LOG"
   collect_log "Act" "$ACT_LOG"
-} > "$REPORT_FILE"
+} > "$REPORT_MD"
 
-echo "Report generated at $REPORT_FILE"
+# Convert Markdown report to HTML
+if python3 -c "import markdown" 2>/dev/null; then
+  python3 <<'PY' "$REPORT_MD" "$REPORT_HTML"
+import sys, markdown, io
+md_path, html_path = sys.argv[1], sys.argv[2]
+with open(md_path, 'r') as f:
+    text = f.read()
+html = markdown.markdown(text)
+with open(html_path, 'w') as f:
+    f.write(html)
+PY
+else
+  html_escaped=$(sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g' "$REPORT_MD")
+  printf '<html><body><pre>%s</pre></body></html>' "$html_escaped" > "$REPORT_HTML"
+fi
+
+echo "Report generated at $REPORT_MD and $REPORT_HTML"


### PR DESCRIPTION
## Summary
- Capture input vectors, lateral movement and mitigation times when generating post-incident reports
- Output structured Markdown and HTML reports including findings, containment actions and recommendations
- Provide sample report and instructor guidance in documentation

## Testing
- `bash -n subcase_1c/scripts/generate_post_incident_report.sh`
- `./subcase_1c/scripts/generate_post_incident_report.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b597efc43c832dafc535b4120f41e6