### PR TITLE
Configure behavioural IDS with Suricata for lab startup

### DIFF
--- a/subcase_1c/ansible/roles/bips/tasks/main.yml
+++ b/subcase_1c/ansible/roles/bips/tasks/main.yml
@@ -40,6 +40,15 @@
     remote_src: yes
   become: yes
 
+- name: Deploy Suricata configuration
+  ansible.builtin.template:
+    src: suricata.yaml.j2
+    dest: /etc/suricata/suricata.yaml
+    owner: root
+    group: root
+    mode: "0644"
+  become: yes
+
 - name: Enable and start Suricata
   ansible.builtin.service:
     name: suricata
@@ -54,6 +63,36 @@
     owner: root
     group: root
     mode: "0644"
+  become: yes
+
+- name: Deploy behavioural monitor script
+  ansible.builtin.template:
+    src: bips_suricata_monitor.py.j2
+    dest: /usr/local/bin/bips_suricata_monitor.py
+    owner: root
+    group: root
+    mode: "0755"
+  become: yes
+
+- name: Install systemd unit for behavioural monitor
+  ansible.builtin.template:
+    src: bips-behavior.service.j2
+    dest: /etc/systemd/system/bips-behavior.service
+    owner: root
+    group: root
+    mode: "0644"
+  become: yes
+
+- name: Reload systemd for BIPS monitor
+  ansible.builtin.systemd:
+    daemon_reload: yes
+  become: yes
+
+- name: Enable and start BIPS behavioural service
+  ansible.builtin.service:
+    name: bips-behavior
+    state: started
+    enabled: yes
   become: yes
 
 - name: Enable and start BIPS service

--- a/subcase_1c/ansible/roles/bips/templates/bips-behavior.service.j2
+++ b/subcase_1c/ansible/roles/bips/templates/bips-behavior.service.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=BIPS behavioural monitor
+After=network.target suricata.service
+Requires=suricata.service
+
+[Service]
+ExecStart=/usr/local/bin/bips_suricata_monitor.py
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/subcase_1c/ansible/roles/bips/templates/bips_suricata_monitor.py.j2
+++ b/subcase_1c/ansible/roles/bips/templates/bips_suricata_monitor.py.j2
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Simple behavioural monitor that tails Suricata EVE JSON alerts."""
+import json
+import pathlib
+import time
+
+EVE_FILE = pathlib.Path("/var/log/suricata/eve.json")
+
+
+def follow(path: pathlib.Path) -> None:
+    if not path.exists():
+        return
+    with path.open() as handle:
+        handle.seek(0, 2)
+        while True:
+            line = handle.readline()
+            if not line:
+                time.sleep(1)
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            alert = event.get("alert")
+            if alert:
+                print(json.dumps({"signature": alert.get("signature"), "severity": alert.get("severity")}), flush=True)
+
+
+if __name__ == "__main__":
+    follow(EVE_FILE)

--- a/subcase_1c/ansible/roles/bips/templates/suricata.yaml.j2
+++ b/subcase_1c/ansible/roles/bips/templates/suricata.yaml.j2
@@ -1,0 +1,18 @@
+%YAML 1.1
+---
+vars:
+  address-groups:
+    HOME_NET: "[10.0.0.0/8]"
+    EXTERNAL_NET: "!$HOME_NET"
+default-log-dir: /var/log/suricata
+rule-files:
+  - bips.rules
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve.json
+      types:
+        - alert:
+            metadata: yes
+            tagged-packets: yes

--- a/subcase_1c/scenario.yml
+++ b/subcase_1c/scenario.yml
@@ -43,6 +43,7 @@ nodes:
     gateway: "10.20.0.1"
     startup_scripts:
       - path: "scripts/start_soc_services.sh"
+      - path: "scripts/bips_start.sh"
   cti_component:
     image: "cti-platform:latest"
     role: "cti"


### PR DESCRIPTION
## Summary
- install Suricata rules and config through BIPS role
- add Python-based behavioural monitor and systemd unit
- start BIPS automatically during scenario boot

## Testing
- `python subcase_1c/scripts/validate_playbooks.py`
- `ansible-playbook subcase_1c/ansible/playbook.yml --syntax-check`
- `ansible-lint subcase_1c/ansible/playbook.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b69e071ca8832d87ebfd70de51e0a6