### PR TITLE
Add BIPS log forwarding and SIEM-friendly alert output

### DIFF
--- a/subcase_1c/ansible/roles/ng_siem/tasks/main.yml
+++ b/subcase_1c/ansible/roles/ng_siem/tasks/main.yml
@@ -30,6 +30,35 @@
     mode: "0644"
   become: yes
 
+- name: Ensure BIPS log directory exists
+  ansible.builtin.file:
+    path: /var/log/bips
+    state: directory
+    mode: "0755"
+  become: yes
+
+- name: Enable BIPS log input for Filebeat
+  ansible.builtin.blockinfile:
+    path: /etc/ng_siem/filebeat.yml
+    marker: "# {mark} ANSIBLE MANAGED BLOCK BIPS"
+    insertafter: '^filebeat.inputs:'
+    block: |2
+      - type: log
+        paths:
+          - /var/log/bips/alerts.json
+        fields:
+          log_type: bips
+        json.keys_under_root: true
+        json.add_error_key: true
+  become: yes
+
+- name: Restart Filebeat
+  ansible.builtin.service:
+    name: filebeat
+    state: restarted
+    enabled: yes
+  become: yes
+
 - name: Configure Winlogbeat
   ansible.builtin.template:
     src: winlogbeat.yml.j2


### PR DESCRIPTION
## Summary
- Forward BIPS alerts through Filebeat by adding dedicated input and directory
- Emit IDS alerts as JSON lines suitable for SIEM ingestion

## Testing
- `python -m py_compile subcase_1c/bips/ids_ml.py`
- `python subcase_1c/bips/ids_ml.py --alert-file /tmp/sample_eve.json`
- `cat /var/log/bips/alerts.json`


------
https://chatgpt.com/codex/tasks/task_e_68b69f6e1a98832d8795f76ef75836d4