### PR TITLE
Deploy ELK stack via ng_siem role and auto-start script

### DIFF
--- a/subcase_1c/ansible/roles/ng_siem/defaults/main.yml
+++ b/subcase_1c/ansible/roles/ng_siem/defaults/main.yml
@@ -1,4 +1,3 @@
 ---
-# Base URL for NG-SOC package repository. Override in inventory or group vars.
-ngsoc_repo_url: "https://packages.internal.example.com"
-ng_siem_server_checksum: "sha256:9e41db92fb36071d913a9a353145ff878a39859ec7da026c11dbe059ddfc2341"
+# Default Elastic Stack version for container images
+elk_version: "8.11.3"

--- a/subcase_1c/ansible/roles/ng_siem/tasks/main.yml
+++ b/subcase_1c/ansible/roles/ng_siem/tasks/main.yml
@@ -1,21 +1,25 @@
-- name: Download NG-SIEM package
-  ansible.builtin.get_url:
-    url: "{{ ngsoc_repo_url }}/ng-siem/ng-siem-server.deb"
-    dest: "/tmp/ng-siem-server.deb"
-    mode: "0644"
-    checksum: "{{ ng_siem_server_checksum }}"
-  become: yes
-
-- name: Install NG-SIEM
-  ansible.builtin.apt:
-    deb: "/tmp/ng-siem-server.deb"
-    state: present
-  become: yes
-
-- name: Configure NG-SIEM
+- name: Deploy ELK docker-compose file
   ansible.builtin.template:
-    src: ng_siem.conf.j2
-    dest: /etc/ng_siem/config.yml
+    src: docker-compose.yml.j2
+    dest: /etc/ng_siem/docker-compose.yml
+    owner: root
+    group: root
+    mode: "0644"
+  become: yes
+
+- name: Deploy default Kibana dashboard
+  ansible.builtin.template:
+    src: kibana-dashboard.ndjson.j2
+    dest: /etc/ng_siem/default-dashboard.ndjson
+    owner: root
+    group: root
+    mode: "0644"
+  become: yes
+
+- name: Deploy Elasticsearch index template
+  ansible.builtin.template:
+    src: index-template.json.j2
+    dest: /etc/ng_siem/index-template.json
     owner: root
     group: root
     mode: "0644"
@@ -68,9 +72,9 @@
     mode: "0644"
   become: yes
 
-- name: Enable and start NG-SIEM service
-  ansible.builtin.service:
-    name: ng-siem
-    state: started
-    enabled: yes
+- name: Launch ELK stack
+  ansible.builtin.command:
+    cmd: docker compose -f /etc/ng_siem/docker-compose.yml up -d
+  args:
+    chdir: /etc/ng_siem
   become: yes

--- a/subcase_1c/ansible/roles/ng_siem/templates/docker-compose.yml.j2
+++ b/subcase_1c/ansible/roles/ng_siem/templates/docker-compose.yml.j2
@@ -1,0 +1,23 @@
+version: '3'
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:{{ elk_version }}
+    environment:
+      - discovery.type=single-node
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+    ports:
+      - "9200:9200"
+    networks:
+      - elk
+  kibana:
+    image: docker.elastic.co/kibana/kibana:{{ elk_version }}
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    ports:
+      - "5601:5601"
+    networks:
+      - elk
+networks:
+  elk:
+    driver: bridge
+

--- a/subcase_1c/ansible/roles/ng_siem/templates/index-template.json.j2
+++ b/subcase_1c/ansible/roles/ng_siem/templates/index-template.json.j2
@@ -1,0 +1,14 @@
+{
+  "index_patterns": ["logs-*"] ,
+  "template": {
+    "settings": {
+      "number_of_shards": 1
+    },
+    "mappings": {
+      "properties": {
+        "@timestamp": { "type": "date" }
+      }
+    }
+  }
+}
+

--- a/subcase_1c/ansible/roles/ng_siem/templates/kibana-dashboard.ndjson.j2
+++ b/subcase_1c/ansible/roles/ng_siem/templates/kibana-dashboard.ndjson.j2
@@ -1,0 +1,2 @@
+{"type":"dashboard","id":"default-dashboard","attributes":{"title":"Default SOC Dashboard","timeRestore":false,"panelsJSON":"[]","optionsJSON":"{}","version":1}}
+


### PR DESCRIPTION
## Summary
- introduce docker-compose based ELK stack for ng_siem role
- provide default Kibana dashboard and Elasticsearch index template
- start the SIEM stack automatically from start_soc_services.sh

## Testing
- `bash -n subcase_1c/scripts/start_soc_services.sh`
- `ansible-playbook --syntax-check subcase_1c/ansible/playbook.yml`

------
https://chatgpt.com/codex/tasks/task_e_68b6a0234d18832d96bcb2678eab6e0d