### PR TITLE
Add SIEM web UI and alert acknowledgement workflow

### DIFF
--- a/docs/subcase_1c_guide.md
+++ b/docs/subcase_1c_guide.md
@@ -1,51 +1,76 @@
 # Subcase 1c Guide: Malware Simulation and CTI Integration
 
 ## Objective
+
 Simulate benign malware activity and integrate threat intelligence feeds to exercise NG-SOC components.
 
 ## Tasks
 
 1. **Start SOC services**
+
    ```bash
    sudo subcase_1c/scripts/start_soc_services.sh
    ```
+
    Launches BIPS, NG-SIEM, CICMS, NG-SOC, Decide, and Act.
    BIPS now includes a Suricata IDS with a lightweight ML classifier that
    processes alerts and enriches rules using indicators from the MISP feed.
    Port checks rely on Bash's `/dev/tcp` and `timeout` rather than `netcat`.
 
 2. **Start CTI component and ingest feeds**
+
    ```bash
    sudo subcase_1c/scripts/start_cti_component.sh
    ```
+
    Runs MISP, starts the `fetch-cti-feed` systemd service, and verifies NG-SIEM.
    Port verification uses the same built-in method to avoid disallowed tools.
    Use `CTI_OFFLINE=1` or run the fetch script with `--offline` to skip external
    downloads when network access is unavailable.
 
-3. **Launch the C2 server**  
+3. **Launch the C2 server**
+
    ```bash
    sudo subcase_1c/scripts/start_c2_server.sh
    ```
 
 4. **Execute the malware simulation on a Windows host**
+
    ```powershell
    $env:BEACON_URL = "http://localhost:5601/beacon"  # optional override
    .\subcase_1c\scripts\benign_malware_simulator.ps1 -BeaconCount 3
    ```
+
    The beacon URL can also be set directly via the `-BeaconUrl` parameter:
+
    ```powershell
    .\subcase_1c\scripts\benign_malware_simulator.ps1 -BeaconCount 3 -BeaconUrl http://ng-siem.local/beacon
    ```
+
    or load via [`load_malware_simulation.ps1`](../subcase_1c/scripts/load_malware_simulation.ps1).
 
 5. **Observe telemetry in NG-SOC tools**
    Monitor BIPS, NG-SIEM, CICMS, NG-SOC, and MISP for beacons, file drops, and CTI correlations.
 
-6. **Request mitigation guidance and apply response**
+6. **Analyst login and triage alerts**
+
+   - Browse to the Kibana dashboard at `http://localhost:5602`.
+   - Log in with the analyst credentials.
+   - Review alerts in the *Security* app and mark them as acknowledged.
+   - Acknowledgement can also be recorded via the Act API:
+
+     ```bash
+     curl -X POST http://localhost:8100/acknowledge \
+          -H 'Content-Type: application/json' \
+          -d '{"alert_id": "abc123", "analyst": "analyst"}'
+     ```
+
+7. **Request mitigation guidance and apply response**
+
    ```bash
    python3 subcase_1c/scripts/apply_mitigation.py 192.0.2.10 --source ng-siem --severity 5
    ```
+
    The script contacts the Act service, which queries Decide for a recommendation and executes the suggested mitigation on the target.
 
 ## Decide→Act Architecture
@@ -55,7 +80,7 @@ The Act service exposes `/act`, forwards the event to Decide, and executes prede
 
 ## Expected Outcomes
 
-- SOC services accessible on ports 5500 (BIPS), 5601 (NG-SIEM), 5800 (CICMS), 5900 (NG-SOC), 8000 (Decide), and 8100 (Act).
+- SOC services accessible on ports 5500 (BIPS), 5601 (NG-SIEM), 5602 (Kibana UI), 5800 (CICMS), 5900 (NG-SOC), 8000 (Decide), and 8100 (Act).
 - MISP running on port 8443 with threat feed ingested.
 - C2 server responding on port 9001.
 - Benign malware simulator generates HTTP beacons and file artifacts detected by NG-SOC components.
@@ -73,4 +98,3 @@ The Act service exposes `/act`, forwards the event to Decide, and executes prede
 - [`benign_malware_simulator.ps1`](../subcase_1c/scripts/benign_malware_simulator.ps1)
 - [`load_malware_simulation.ps1`](../subcase_1c/scripts/load_malware_simulation.ps1)
 - [NG-SOC components matrix](ngsoc_components_matrix.md)
-


### PR DESCRIPTION
## Summary
- start Kibana container in `start_soc_services.sh` and expose configurable SIEM UI port
- document analyst login and alert triage steps in subcase 1c guide
- add `/acknowledge` endpoint in Act service for sample alert acknowledgement

## Testing
- `python -m py_compile subcase_1c/act/act.py`
- `bash -n subcase_1c/scripts/start_soc_services.sh`
- `markdownlint --disable MD013 -- docs/subcase_1c_guide.md`


------
https://chatgpt.com/codex/tasks/task_e_68b6a1765e38832dbc22fae96564c62a