### PR TITLE
Add Subcase 1c guide with deployment, simulation, and validation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This repository provides complete, ready‑to‑deploy instructions for double K
 2. **Authenticate to CyberRangeCZ** – Ensure VPN or direct connectivity and log into the portal.
 3. **Prepare the Scenario** – Upload required images or scripts (e.g., `subcase_1c/scripts/benign_malware_simulator.ps1`) to the appropriate KYPO repositories.
 4. **Launch the Scenario** – Use the KYPO interface to create a new exercise and point it to this repository. Configure network ranges and participants as needed.
-5. **Monitor the Exercise** – During execution, analysts should track alerts and manage cases using NG-SOC components such as BIPS, NG-SIEM, CICMS, and MISP (for CTI sharing), following the workflow described in [`docs/training_workflows.md`](docs/training_workflows.md).
+5. **Monitor the Exercise** – During execution, analysts should track alerts and manage cases using NG-SOC components such as BIPS, NG-SIEM, CICMS, and MISP (for CTI sharing), following the workflow described in [`docs/training_workflows.md`](docs/training_workflows.md) and the deployment/validation steps in [`docs/subcase_1c_guide.md`](docs/subcase_1c_guide.md).
 
 ### Phishing Quiz Module
 
@@ -54,7 +54,7 @@ Additional theoretical background and workflow guidance can be found in [`docs/t
 - [Subcase 1b – Penetration Testing Training](docs/subcase_1b_guide.md)
 Subcase 1b delivers self-paced penetration testing and vulnerability assessment training using a dedicated training platform, a trainee workstation, and a Cyber Range simulation of CYNET's network.
 - [Subcase 1c – Malware Simulation and CTI Integration](docs/subcase_1c_guide.md)
-Subcase 1c models a malware incident response exercise, adding a C2 server, a CTI component running MISP, and corresponding services for NG‑SIEM, BIPS, CICMS, and NG‑SOC. The roles download NG‑SOC packages with checksum verification, and the scripts launch services and simulations for training.
+Subcase 1c models a malware incident response exercise, adding a C2 server, a CTI component running MISP, and corresponding services for NG‑SIEM, BIPS, CICMS, and NG‑SOC. The guide covers deployment, attack simulation, validation, and configuration of detection rules and playbooks.
 
 ## KYPO Training Packaging
 

--- a/docs/training_workflows.md
+++ b/docs/training_workflows.md
@@ -76,6 +76,9 @@ course progress, and relays that progress to the Open edX
 
 ## Subcase 1c: Malware Handling
 
+For detailed deployment, attack simulation, and validation procedures see the
+[Subcase 1c guide](subcase_1c_guide.md).
+
 ### Trainee Activities
 
 1. **Lab Deployment** – Start the Subcase 1c lab in the KYPO interface. *Validation:* confirm all virtual machines show a **running** state in the platform dashboard. *Artifacts:* screenshot of the deployment status and exported topology details.

--- a/training.yaml
+++ b/training.yaml
@@ -14,6 +14,6 @@ training:
         - id: subcase_1b
           topology: sandboxes/topology_subcase_1b.yaml
           provisioning: sandboxes/provisioning_subcase_1b/site.yml
-        - id: subcase_1c
+        - id: subcase_1c  # see docs/subcase_1c_guide.md for deployment and validation steps
           topology: sandboxes/topology_subcase_1c.yaml
           provisioning: sandboxes/provisioning_subcase_1c/site.yml


### PR DESCRIPTION
## Summary
- Rewrite Subcase 1c guide to cover deployment, attack simulation, validation, and configuration of malware detection rules and SOAR playbooks
- Reference the new guide from the root README, training workflows, and training config

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6a2bc3484832d8be7fab03e9df1ef