### PR TITLE
Add KYPO lab launch component and documentation

### DIFF
--- a/docs/kypo_launch_component_snippet.xml
+++ b/docs/kypo_launch_component_snippet.xml
@@ -1,0 +1,9 @@
+<!-- Example snippet for embedding the KYPO launch component in Open edX -->
+<vertical display_name="KYPO Lab Example">
+  <html display_name="KYPO Lab Launcher">
+    <![CDATA[
+    <iframe src="http://localhost:5000/kypo_launch_component.html?token={{token}}&lab_id=intro-lab"
+            width="800" height="600" frameborder="0"></iframe>
+    ]]>
+  </html>
+</vertical>

--- a/docs/subcase_1b_guide.md
+++ b/docs/subcase_1b_guide.md
@@ -153,6 +153,13 @@ LMS should redirect the learner’s browser to that URL to open the lab.
 5. Mark the component as **graded** if the KYPO exercise should
    contribute to the course score and assign an appropriate weight.
 
+> **Deployment note:** After enabling `lti_consumer`, instructors should
+> preview the unit in Studio to confirm the integration. Clicking the
+> **Launch KYPO Lab** button should call the training platform’s
+> `/kypo/launch` endpoint and redirect the browser to the KYPO lab. If
+> no redirect occurs, verify that the training platform is running and
+> that the lab identifier matches an available exercise.
+
 When a learner accesses the unit, Open edX posts the parameters to the
 training platform. The platform validates the token, generates a signed
 LTI launch URL, and returns it to the LMS which then redirects the

--- a/subcase_1b/training_platform/kypo_launch_component.html
+++ b/subcase_1b/training_platform/kypo_launch_component.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>KYPO Lab Launcher</title>
+</head>
+<body>
+  <button id="launch-btn">Launch KYPO Lab</button>
+  <script>
+    async function launchLab() {
+      const params = new URLSearchParams(window.location.search);
+      const token = params.get('token');
+      const labId = params.get('lab_id');
+      try {
+        const res = await fetch('/kypo/launch', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ token: token, lab_id: labId })
+        });
+        if (!res.ok) {
+          alert('Lab launch failed');
+          return;
+        }
+        const data = await res.json();
+        if (data.launch_url) {
+          window.location.href = data.launch_url;
+        } else {
+          alert('No launch URL returned');
+        }
+      } catch (err) {
+        alert('Lab launch failed');
+      }
+    }
+
+    document.getElementById('launch-btn').addEventListener('click', launchLab);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add HTML sample that posts to `/kypo/launch` and redirects to returned LTI URL
- document how to embed the component in Open edX with an XML snippet
- note how instructors enable and verify the KYPO launch in Studio

## Testing
- `python -m py_compile subcase_1b/training_platform/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6b714a564832d9589fea50abb5750