### PR TITLE
Specify concrete VM images and provisioning for CYNET scenarios

### DIFF
--- a/docs/cynet_topology.md
+++ b/docs/cynet_topology.md
@@ -1,0 +1,21 @@
+# CYNET Topology Overview
+
+## Subcase 1b
+- Network segment `training_net` (10.10.0.0/24)
+- Virtual machines:
+  - **training_platform** – Debian 11
+  - **trainee_workstation** – Kali
+  - **cyber_range** – Metasploitable2
+  - **randomization_platform** – Debian 11
+  - **bips** – Debian 11
+  - **ng_siem** – Debian 11
+  - **cicms** – Debian 11
+  - **ng_soc** – Debian 11
+
+## Subcase 1c
+- Network segment `malnet` (10.20.0.0/24)
+- Virtual machines:
+  - **infected_host** – Kali
+  - **c2_server** – Debian 11
+  - **soc_server** – Debian 11
+  - **cti_component** – Debian 11

--- a/sandboxes/provisioning_subcase_1b/site.yml
+++ b/sandboxes/provisioning_subcase_1b/site.yml
@@ -1,4 +1,45 @@
 ---
+- hosts: training_platform
+  become: yes
+  tasks:
+    - name: Install training web server
+      apt:
+        name: nginx
+        state: present
+    - name: Ensure nginx running
+      service:
+        name: nginx
+        state: started
+        enabled: yes
+
+- hosts: trainee_workstation
+  become: yes
+  tasks:
+    - name: Install pentest tools
+      apt:
+        name:
+          - nmap
+          - gvm
+        state: present
+
+- hosts: cyber_range
+  become: yes
+  tasks:
+    - name: Install DVWA dependencies
+      apt:
+        name:
+          - apache2
+          - mysql-server
+        state: present
+
+- hosts: randomization_platform
+  become: yes
+  tasks:
+    - name: Install randomization utilities
+      apt:
+        name: python3
+        state: present
+
 - hosts: bips
   become: yes
   tasks:
@@ -19,6 +60,14 @@
         name: ng-siem
         state: started
         enabled: yes
+
+- hosts: cicms
+  become: yes
+  tasks:
+    - name: Install CICMS service
+      apt:
+        name: cicms
+        state: present
 
 - hosts: ng_soc
   become: yes

--- a/sandboxes/provisioning_subcase_1c/site.yml
+++ b/sandboxes/provisioning_subcase_1c/site.yml
@@ -7,6 +7,7 @@
         name:
           - tcpdump
           - netcat
+          - powershell
         state: present
 
 - hosts: c2_server

--- a/subcase_1b/scenario.yml
+++ b/subcase_1b/scenario.yml
@@ -8,12 +8,13 @@ metadata:
   difficulty: "medium"
   created: "2024-01-01"
 network:
+  name: "training_net"
   subnet: "10.10.0.0/24"
   gateway: "10.10.0.1"
 playbook: "ansible/playbook.yml"
 nodes:
   training_platform:
-    image: "course-platform:latest"
+    image: "debian-11"
     role: "instructor"
     services:
       - "Course Management"
@@ -24,7 +25,7 @@ nodes:
       - path: "scripts/training_platform_start.sh"
         args: "--course pentest-101"
   trainee_workstation:
-    image: "pentest-workstation:latest"
+    image: "kali"
     role: "trainee"
     ip: "10.10.0.3"
     subnet: "10.10.0.0/24"
@@ -33,7 +34,7 @@ nodes:
       - path: "scripts/trainee_start.sh"
         args: "--target 10.10.0.4"
   cyber_range:
-    image: "cyber-range-sim:latest"
+    image: "metasploitable2"
     role: "range"
     services:
       - "Simulated CYNET Network"
@@ -44,7 +45,7 @@ nodes:
       - path: "scripts/cyber_range_start.sh"
         args: "--vuln-profile baseline"
   randomization_platform:
-    image: "randomization-platform:latest"
+    image: "debian-11"
     role: "randomization"
     services:
       - "Randomization Evaluation"
@@ -54,7 +55,7 @@ nodes:
     startup_scripts:
       - path: "scripts/randomization_platform_start.sh"
   bips:
-    image: "bips:latest"
+    image: "debian-11"
     role: "security"
     services:
       - "Behavioral IPS"
@@ -64,7 +65,7 @@ nodes:
     startup_scripts:
       - path: "scripts/bips_start.sh"
   ng_siem:
-    image: "ng-siem:latest"
+    image: "debian-11"
     role: "siem"
     services:
       - "Next-Gen SIEM"
@@ -74,7 +75,7 @@ nodes:
     startup_scripts:
       - path: "scripts/ng_siem_start.sh"
   cicms:
-    image: "cicms:latest"
+    image: "debian-11"
     role: "incident_management"
     services:
       - "Cyber Incident & Case Management"
@@ -84,7 +85,7 @@ nodes:
     startup_scripts:
       - path: "scripts/cicms_start.sh"
   ng_soc:
-    image: "ng-soc:latest"
+    image: "debian-11"
     role: "soc"
     services:
       - "Next-Gen SOC"

--- a/subcase_1c/scenario.yml
+++ b/subcase_1c/scenario.yml
@@ -8,12 +8,13 @@ metadata:
   difficulty: "medium"
   created: "2024-01-01"
 network:
+  name: "malnet"
   subnet: "10.20.0.0/24"
   gateway: "10.20.0.1"
 playbook: "ansible/playbook.yml"
 nodes:
   infected_host:
-    image: "windows10:latest"
+    image: "kali"
     role: "victim"
     ip: "10.20.0.2"
     subnet: "10.20.0.0/24"
@@ -22,7 +23,7 @@ nodes:
       - path: "scripts/load_malware_simulation.ps1"
         args: "-ExecutionPolicy Bypass"
   c2_server:
-    image: "c2-server:latest"
+    image: "debian-11"
     role: "c2"
     ip: "10.20.0.3"
     subnet: "10.20.0.0/24"
@@ -31,7 +32,7 @@ nodes:
       - path: "scripts/start_c2_server.sh"
         args: "--config /etc/c2.conf"
   soc_server:
-    image: "soc-platform:latest"
+    image: "debian-11"
     role: "soc"
     services:
       - "NG-SOC"
@@ -45,7 +46,7 @@ nodes:
       - path: "scripts/start_soc_services.sh"
       - path: "scripts/bips_start.sh"
   cti_component:
-    image: "cti-platform:latest"
+    image: "debian-11"
     role: "cti"
     services:
       - "MISP"


### PR DESCRIPTION
## Summary
- Define Kali, Debian, and Metasploitable images with named network segments in subcase scenarios.
- Expand provisioning playbooks to install required packages for each VM.
- Document CYNET network segments and hosts in new topology overview.

## Testing
- `kypo training validate` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b6b7d606d0832db70411447a9ad18c