### PR TITLE
Add Open edX content and phishing questionnaire

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ Running `subcase_1b/scripts/training_platform_start.sh` launches a training plat
 
 See [`docs/subcase_1b_guide.md`](docs/subcase_1b_guide.md) for detailed examples.
 
+### Importing Open edX Content
+
+Sample lessons and a quiz are provided under `open_edx/course`. To load this material into Open edX Studio:
+
+1. Archive the directory:
+   ```bash
+   zip -r phishing_course.zip open_edx/course
+   ```
+2. In Studio, open the target course and navigate to **Tools → Import**.
+3. Upload `phishing_course.zip` to add the lessons and quiz.
+
 ## Teardown
 
 1. Stop the scenario from the KYPO dashboard.

--- a/docs/phishing_questionnaire.md
+++ b/docs/phishing_questionnaire.md
@@ -1,0 +1,37 @@
+# Phishing Awareness Questionnaire
+
+Use this questionnaire to assess how well trainees can identify phishing threats. Questions can be served by the training platform and scored automatically.
+
+## Sample Questions
+
+1. **What is the safest response to an unexpected password reset email?**
+   - A. Click the link and change your password
+   - B. Ignore the email
+   - C. Verify the request through an official channel
+2. **Which URL is likely malicious?**
+   - A. `https://accounts.example.com`
+   - B. `http://login.example.com.security-update.co`
+   - C. `https://intranet.example.com/profile`
+3. **Why should you hover over links before clicking?**
+   - A. To check the true destination
+   - B. To download the attachment
+   - C. To enable pop-up blockers
+
+## Scoring via Training Platform
+
+The training platform exposes endpoints that handle quiz distribution and scoring:
+
+```bash
+# Obtain questions
+curl http://localhost:5000/quiz/start
+
+# Submit answers for grading
+curl -X POST http://localhost:5000/quiz/submit \
+  -H 'Content-Type: application/json' \
+  -d '{"user":"alice","answers":{"q1":"C","q2":"B","q3":"A"}}'
+
+# Retrieve the stored score
+curl http://localhost:5000/quiz/score?user=alice
+```
+
+These endpoints allow instructors to integrate phishing assessments into automated training workflows and track learner performance over time.

--- a/open_edx/course/lessons/phishing_examples.html
+++ b/open_edx/course/lessons/phishing_examples.html
@@ -1,0 +1,8 @@
+<h2>Recognizing Phishing Emails</h2>
+<p>The following screenshot demonstrates common red flags:</p>
+<ul>
+  <li>Mismatched domain names in hyperlinks</li>
+  <li>Urgent requests for password resets</li>
+  <li>Poor grammar or unexpected attachments</li>
+</ul>
+<p>Always verify the sender and never provide credentials through email forms.</p>

--- a/open_edx/course/lessons/phishing_overview.md
+++ b/open_edx/course/lessons/phishing_overview.md
@@ -1,0 +1,9 @@
+# Phishing Fundamentals
+
+Phishing attacks attempt to trick users into revealing sensitive information or executing malicious actions.
+
+- Inspect email senders and URLs before clicking.
+- Report suspicious messages to security teams immediately.
+- Use multi-factor authentication to mitigate account compromise.
+
+These concepts lay the groundwork for the practical quiz that follows.

--- a/open_edx/course/quizzes/phishing_quiz.xml
+++ b/open_edx/course/quizzes/phishing_quiz.xml
@@ -1,0 +1,10 @@
+<problem>
+  <multiplechoiceresponse>
+    <label>Which sign indicates a potential phishing email?</label>
+    <choicegroup type="MultipleChoice">
+      <choice correct="true">A request for credentials via an unsolicited link</choice>
+      <choice>A personalized greeting from your colleague</choice>
+      <choice>An email from your IT team sent through the company helpdesk</choice>
+    </choicegroup>
+  </multiplechoiceresponse>
+</problem>


### PR DESCRIPTION
## Summary
- Add sample Open edX lessons and quiz under `open_edx/course` for phishing awareness training.
- Provide a phishing questionnaire in `docs` with examples on submitting answers to existing training platform scoring endpoints.
- Update README with steps for importing the Open edX materials into Studio.

## Testing
- `kypo training validate training.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6bd1b9544832d8a413ab1b9b08e7e