### PR TITLE
Add SOC analyst playbook and link into training guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Sample lessons and a quiz are provided under `open_edx/course`. To load this mat
 - **Scenario Fails to Start** – Ensure all prerequisite images are uploaded and that the repository path is correct.
 - **Tool-Specific Logs** – Consult documentation for [BIPS](https://ngsoc.example.com/bips), [NG-SIEM](https://ngsoc.example.com/ng-siem), [CICMS](https://ngsoc.example.com/cicms), and [MISP](https://ngsoc.example.com/misp).
 
-Additional theoretical background and workflow guidance can be found in [`docs/training_workflows.md`](docs/training_workflows.md).
+Additional theoretical background and workflow guidance can be found in [`docs/training_workflows.md`](docs/training_workflows.md). For day‑to‑day alert handling, analysts should review the [`SOC Analyst Playbook`](docs/soc_analyst_playbook.md).
 
 ## Scenario Guides
 

--- a/docs/soc_analyst_playbook.md
+++ b/docs/soc_analyst_playbook.md
@@ -1,0 +1,37 @@
+# SOC Analyst Playbook
+
+This playbook guides analysts through NG-SOC dashboards, typical search queries, and criteria for confirming alerts. It also highlights CACAO playbooks executed through Act.
+
+## Dashboard Navigation
+
+1. **Access Kibana** at `http://localhost:5602` and log in with analyst credentials.
+2. Navigate to the **Security** app to view correlated alerts.
+3. Use the **Discover** tab for raw event inspection and timeline analysis.
+4. Open the **Dashboards** section for visual summaries of BIPS, NG‑SIEM, and CICMS data.
+
+## Search Queries
+
+- `BenignMalwareSim` – confirm logs from the simulator reach NG‑SIEM.
+- `event.type:alert and host.name:win-*` – list alerts from Windows hosts.
+- `source.ip:192.0.2.* and destination.port:9001` – trace beacon traffic to the C2 server.
+- `process.executable:*powershell* and event.action:creation` – identify suspicious PowerShell usage.
+
+## Confirming Alerts
+
+An alert is considered confirmed when:
+
+1. **Correlation** – Indicators match threat intelligence entries in MISP and align with simulator activity.
+2. **Host Verification** – Host logs show associated processes, files, or registry changes.
+3. **Network Evidence** – NG‑SIEM or packet captures show traffic consistent with the alert.
+4. **No Benign Explanation** – Cross‑check with training scripts to rule out expected actions.
+5. Record confirmation in CICMS/Act via the appropriate API calls.
+
+## Response Playbooks
+
+| Playbook | Purpose | When to Execute |
+|---------|---------|----------------|
+| [`isolation.yml`](../subcase_1c/playbooks/isolation.yml) | Disconnect a compromised host to prevent spread. | Execute when initial triage shows active compromise or lateral movement. |
+| [`eradication.yml`](../subcase_1c/playbooks/eradication.yml) | Remove malware artifacts and clean quarantine directories. | Run after isolation to eliminate confirmed malicious components. |
+| [`recovery.yml`](../subcase_1c/playbooks/recovery.yml) | Restore network connectivity and verify critical services. | Apply once eradication is complete and the host is ready to return to production. |
+
+Following this guide ensures analysts can navigate dashboards, perform targeted searches, confirm alerts, and trigger the correct automation playbook during incident response.

--- a/docs/subcase_1b_guide.md
+++ b/docs/subcase_1b_guide.md
@@ -60,6 +60,7 @@ flowchart TD
      ```bash
      sudo subcase_1b/scripts/ng_soc_start.sh
      ```
+   - Analysts monitoring these services can follow the [SOC Analyst Playbook](soc_analyst_playbook.md) for dashboard navigation, search queries, and alert confirmation criteria.
 4. **Review Trainee Reports** – Evaluate submitted findings from penetration test runs.
 
 ## Trainee Steps

--- a/docs/subcase_1c_guide.md
+++ b/docs/subcase_1c_guide.md
@@ -84,15 +84,17 @@ expected.
 4. **Analyst login and triage alerts**
 
    - Browse to the Kibana dashboard at `http://localhost:5602`.
-   - Log in with analyst credentials.
-   - Review alerts in the *Security* app and mark them as acknowledged.
-   - Acknowledgement can also be recorded via the Act API:
+  - Log in with analyst credentials.
+  - Review alerts in the *Security* app and mark them as acknowledged.
+  - Acknowledgement can also be recorded via the Act API:
 
      ```bash
-     curl -X POST http://localhost:8100/acknowledge \
-          -H 'Content-Type: application/json' \
-          -d '{"alert_id": "abc123", "analyst": "analyst"}'
-     ```
+    curl -X POST http://localhost:8100/acknowledge \
+         -H 'Content-Type: application/json' \
+         -d '{"alert_id": "abc123", "analyst": "analyst"}'
+    ```
+
+   Analysts can reference the [SOC Analyst Playbook](soc_analyst_playbook.md) for deeper guidance on navigation, search queries, and alert confirmation.
 
 5. **Verify BIPS alerts**
 

--- a/docs/training_workflows.md
+++ b/docs/training_workflows.md
@@ -1,6 +1,6 @@
 # Training Materials and Workflows
 
-This document outlines the theoretical training materials and the workflow expectations for both trainees and instructors operating within the KYPO cyber range environment. The primary scenario focuses on penetration testing and vulnerability assessment training using a Cyber Range environment that mirrors CYNET's network. Participants learn how to discover and document vulnerabilities while following organizational procedures.
+This document outlines the theoretical training materials and the workflow expectations for both trainees and instructors operating within the KYPO cyber range environment. The primary scenario focuses on penetration testing and vulnerability assessment training using a Cyber Range environment that mirrors CYNET's network. Participants learn how to discover and document vulnerabilities while following organizational procedures. For operational alert triage in NG‑SOC tools, refer to the [SOC Analyst Playbook](soc_analyst_playbook.md).
 
 ## Theoretical Background
 


### PR DESCRIPTION
## Summary
- Document SOC dashboard navigation, sample queries, alert confirmation steps, and response playbooks.
- Cross-link the new playbook from README and all training guides for easy analyst reference.

## Testing
- `kypo training validate training.yaml` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests'; No module named 'yara')*


------
https://chatgpt.com/codex/tasks/task_e_68b6beb1b548832da82d97cb5a13330d