### PR TITLE
Replace rustscan with nmap

### DIFF
--- a/docs/dependency_notes.md
+++ b/docs/dependency_notes.md
@@ -2,7 +2,7 @@
 
 This repository replaces disallowed utilities with tools from the approved list.
 
-- `rustscan`: Used in `subcase_1b/scripts/trainee_start.sh` to perform port scans instead of `nmap`. Rustscan is an approved scanning utility.
+- `nmap`: Used in `subcase_1b/scripts/trainee_start.sh` to perform port scans. Nmap is an approved scanning utility.
 - `timeout` (from `coreutils`): Required by `subcase_1c/scripts/start_cti_component.sh` and `subcase_1c/scripts/start_soc_services.sh` to verify TCP ports using Bash's `/dev/tcp` feature. This replaces `netcat` and keeps the implementation within permitted system utilities.
 
 No additional network tools are necessary; standard systemd and Bash components remain.

--- a/docs/subcase_1b_guide.md
+++ b/docs/subcase_1b_guide.md
@@ -74,12 +74,12 @@ flowchart TD
    sudo subcase_1b/scripts/trainee_start.sh --target 10.10.0.4
    ```
    The script sequentially executes:
-   - `rustscan` for port enumeration
+   - `nmap` for port enumeration
    - an OpenVAS quick scan via `gvm-script`
    - an OWASP ZAP quick scan that saves an HTML report
 
    Output from each tool is appended to `/var/log/trainee/scans.log`. Successful runs record messages such as:
-   - `Completed rustscan against 10.10.0.4`
+   - `Completed nmap scan against 10.10.0.4`
    - `Completed OpenVAS scan against 10.10.0.4`
    - `Completed OWASP ZAP scan against 10.10.0.4`
 

--- a/subcase_1b/scripts/trainee_start.sh
+++ b/subcase_1b/scripts/trainee_start.sh
@@ -25,7 +25,7 @@ apt_update_once() {
 install_deps() {
     local apt_missing=()
     local snap_missing=()
-    command -v rustscan >/dev/null 2>&1 || apt_missing+=(rustscan)
+    command -v nmap >/dev/null 2>&1 || apt_missing+=(nmap)
     command -v jq >/dev/null 2>&1 || apt_missing+=(jq)
     command -v gvm-script >/dev/null 2>&1 || apt_missing+=(gvm)
     command -v zaproxy >/dev/null 2>&1 || snap_missing+=(zaproxy)
@@ -49,13 +49,13 @@ install_deps() {
     fi
 }
 
-run_rustscan() {
-    if result=$(rustscan -a "$TARGET" 2>&1); then
+run_nmap_scan() {
+    if result=$(nmap -p- "$TARGET" 2>&1); then
         printf '%s\n' "$result" >> "$SCAN_LOG"
-        echo "$(date) Completed rustscan against $TARGET" >> "$SCAN_LOG"
+        echo "$(date) Completed nmap scan against $TARGET" >> "$SCAN_LOG"
         send_results "$result"
     else
-        echo "$(date) Rustscan failed for $TARGET" >> "$SCAN_LOG"
+        echo "$(date) Nmap scan failed for $TARGET" >> "$SCAN_LOG"
     fi
 }
 
@@ -86,7 +86,7 @@ run_zap_scan() {
 
 run_scans() {
     mkdir -p "$(dirname "$SCAN_LOG")"
-    run_rustscan
+    run_nmap_scan
     run_openvas_scan
     run_zap_scan
 }


### PR DESCRIPTION
## Summary
- switch trainee workstation scan script from rustscan to nmap
- update docs and dependency notes to reference nmap

## Testing
- `bash -n subcase_1b/scripts/trainee_start.sh`
- `shellcheck subcase_1b/scripts/trainee_start.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b6e04e3134832d8a34af71d9387c50