### PR TITLE
Add Caldera exploitation workflow

### DIFF
--- a/docs/subcase_1b_guide.md
+++ b/docs/subcase_1b_guide.md
@@ -74,16 +74,20 @@ flowchart TD
    sudo subcase_1b/scripts/trainee_start.sh --target 10.10.0.4
    ```
    The script sequentially executes:
-   - `nmap` for port enumeration
+   - an `nmap` reconnaissance sweep with service banner and OS detection
+   - a full TCP port scan using `nmap`
    - an OpenVAS quick scan via `gvm-script`
    - an OWASP ZAP quick scan that saves an HTML report
+   - a Caldera `sandcat` agent that connects to the Caldera server and launches a demo operation
 
    Output from each tool is appended to `/var/log/trainee/scans.log`. Successful runs record messages such as:
+   - `Reconnaissance succeeded against 10.10.0.4`
    - `Completed nmap scan against 10.10.0.4`
+   - `Caldera operation completed`
    - `Completed OpenVAS scan against 10.10.0.4`
    - `Completed OWASP ZAP scan against 10.10.0.4`
 
-   Results are forwarded to the NG-SIEM ingestion endpoint and completion is reported back to the training platform.
+   After the tools finish, the script checks for these indicators and logs an overall pass/fail evaluation. Results are forwarded to the NG-SIEM ingestion endpoint and completion is reported back to the training platform.
 4. Document discovered vulnerabilities and provide them to the instructor.
 
 ## Phishing Awareness Quiz

--- a/subcase_1b/README.md
+++ b/subcase_1b/README.md
@@ -23,6 +23,8 @@ sudo subcase_1b/scripts/trainee_start.sh --target 10.10.0.4  # run sample scan
 
 The training platform records course creation in `/var/log/training_platform/courses.log`. Trainee scan results are written to `/var/log/trainee/scans.log`, and the Cyber Range initialization log is at `/var/log/cyber_range/launch.log`.
 
+The trainee script performs an additional reconnaissance sweep with service and OS fingerprinting and deploys a Caldera `sandcat` agent to execute a demonstration operation. Instructors can verify successful runs by reviewing `/var/log/trainee/scans.log` for entries such as `Reconnaissance succeeded` and `Caldera operation completed`.
+
 ## Virtualization
 
 The cyber range is provisioned using Docker Compose. The `scripts/cyber_range_start.sh` helper launches or tears down the containerized environment:


### PR DESCRIPTION
## Summary
- expand trainee script with nmap reconnaissance, Caldera agent demo, and log evaluation
- document new recon/exploitation steps in trainee guide
- note Caldera verification in subcase README

## Testing
- `shellcheck subcase_1b/scripts/trainee_start.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b6e32d11b0832daa1d9d0c9fd67ab5