### PR TITLE
Integrate IRIS case creation and MISP indicator push

### DIFF
--- a/docs/subcase_1c_guide.md
+++ b/docs/subcase_1c_guide.md
@@ -138,6 +138,15 @@ expected.
    - Benign malware simulator generates HTTP beacons and file artifacts detected
      by NG‑SOC components.
 
+3. **Observe incident propagation and containment**
+
+   - Visit IRIS at `http://localhost:5800/incidents` to verify a case was
+     created from the IDS alert.
+   - In the MISP UI at `http://localhost:8443`, confirm that the indicator
+     associated with the alert appears in the event list.
+   - Review `/var/log/bips/sequence.log` or Act service logs to ensure the
+     recommended mitigation executed automatically in the KYPO environment.
+
 ## References
 
 - [`start_soc_services.sh`](../subcase_1c/scripts/start_soc_services.sh)

--- a/subcase_1c/scripts/start_soc_services.sh
+++ b/subcase_1c/scripts/start_soc_services.sh
@@ -20,6 +20,24 @@ DECIDE_PORT="${DECIDE_PORT:-8000}"
 ACT_PORT="${ACT_PORT:-8100}"
 SIEM_UI_PORT="${SIEM_UI_PORT:-5602}"
 
+LOG_DIR="/var/log/soc_services"
+LOG_FILE="${LOG_DIR}/start.log"
+mkdir -p "${LOG_DIR}"
+
+export IRIS_URL="${IRIS_URL:-http://localhost:${CICMS_PORT}/incidents}"
+export MISP_URL="${MISP_URL:-http://localhost:8443}"
+export MISP_API_KEY="${MISP_API_KEY:-changeme}"
+export DECIDE_URL="http://localhost:${DECIDE_PORT}/recommend"
+export ACT_URL="http://localhost:${ACT_PORT}/act"
+
+{
+    echo "$(date) Starting SOC services"
+    echo "IRIS_URL=${IRIS_URL}"
+    echo "MISP_URL=${MISP_URL}"
+    echo "DECIDE_URL=${DECIDE_URL}"
+    echo "ACT_URL=${ACT_URL}"
+} >>"${LOG_FILE}"
+
 APT_UPDATED=0
 apt_update_once() {
     if [ "$APT_UPDATED" -eq 0 ]; then
@@ -294,3 +312,22 @@ start_cicms
 start_ng_soc
 start_decide
 start_act
+
+{
+    echo "$(date) BIPS_URL=http://localhost:${BIPS_PORT}"
+    echo "$(date) IRIS_URL=${IRIS_URL}"
+    echo "$(date) MISP_URL=${MISP_URL}"
+    echo "$(date) DECIDE_URL=${DECIDE_URL}"
+    echo "$(date) ACT_URL=${ACT_URL}"
+    echo "$(date) alert->case->response sequence logged at /var/log/bips/sequence.log"
+} >>"${LOG_FILE}"
+
+cat <<EOM
+SOC services started. Endpoints:
+  BIPS    http://localhost:${BIPS_PORT}
+  IRIS    ${IRIS_URL}
+  MISP    ${MISP_URL} (key: ${MISP_API_KEY})
+  Decide  ${DECIDE_URL}
+  Act     ${ACT_URL}
+Logs at ${LOG_FILE} and /var/log/bips/sequence.log
+EOM


### PR DESCRIPTION
## Summary
- Post malicious IDS alerts to IRIS incidents, push indicators to MISP, and trigger Act mitigations
- Export service endpoints and log alert→case→response in startup script
- Document how to validate IRIS cases, MISP updates, and automated containment in KYPO

## Testing
- `python -m py_compile subcase_1c/bips/ids_ml.py`
- `bash -n subcase_1c/scripts/start_soc_services.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6e4b3fd10832d90d829906a870d76