### PR TITLE
docs: expand training workflows and analyst checklist

### DIFF
--- a/docs/subcase_1c_guide.md
+++ b/docs/subcase_1c_guide.md
@@ -147,6 +147,12 @@ expected.
    - Review `/var/log/bips/sequence.log` or Act service logs to ensure the
      recommended mitigation executed automatically in the KYPO environment.
 
+## SOC Analyst Checklist
+
+- **View IRIS cases** – Confirm that each IDS alert generates a case in the incident registry.
+- **Verify MISP entries** – Ensure indicators from the simulation appear in the threat feed and are linked to the case.
+- **Confirm automated responses** – Check BIPS or Act logs to validate that recommended mitigations executed without manual intervention.
+
 ## References
 
 - [`start_soc_services.sh`](../subcase_1c/scripts/start_soc_services.sh)

--- a/subcase_1c/README.md
+++ b/subcase_1c/README.md
@@ -7,6 +7,8 @@ protection capabilities and capacities using state-of-the-art technology and sol
 
 Simulate benign malware activity and integrate threat intelligence feeds to exercise NG-SOC components.
 
+This subcase is **hands-on**. Analysts can inspect outputs in the NG-SIEM dashboards at `http://localhost:5602`, review MISP entries at `https://localhost:8443`, and examine raw logs under `/var/log/bips/` and the Act service log directory.
+
 ## Node Roles
 - **infected_host** – Windows victim that runs the benign malware simulator
 - **c2_server** – Command-and-control server for beaconing traffic


### PR DESCRIPTION
## Summary
- add instructor setup and trainee workflow guidance for subcase 1b
- document SOC analyst checklist for subcase 1c
- note hands-on nature of subcase 1c and log locations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6e60b0d90832d88423a7d8d9efe0d