### PR TITLE
Add NG-SOC private APT repository for sandbox provisioning

### DIFF
--- a/sandboxes/provisioning_subcase_1b/README.md
+++ b/sandboxes/provisioning_subcase_1b/README.md
@@ -1,0 +1,29 @@
+# Provisioning Subcase 1b Packages
+
+This directory contains example automation for provisioning the subcase 1b sandbox. The NG-SOC
+components are distributed through a private APT repository. Each host installs the required
+package from this repository, or alternatively, container images can be used.
+
+## Package locations
+
+| Component | Deb package URL | Container image |
+|-----------|-----------------|-----------------|
+| BIPS | https://ngsoc.example.com/apt/pool/bips/bips-agent.deb | registry.example.com/ngsoc/bips:latest |
+| NG-SIEM | https://ngsoc.example.com/apt/pool/ng-siem/ng-siem-server.deb | registry.example.com/ngsoc/ng-siem:latest |
+| CICMS | https://ngsoc.example.com/apt/pool/cicms/cicms-server.deb | registry.example.com/ngsoc/cicms:latest |
+| NG-SOC | https://ngsoc.example.com/apt/pool/ng-soc/ng-soc-platform.deb | registry.example.com/ngsoc/ng-soc:latest |
+
+## Adding the private APT repository
+
+The playbook in this folder adds the repository automatically, but manual setup can be performed
+as follows:
+
+```bash
+echo 'deb [trusted=yes] https://ngsoc.example.com/apt stable main' | \
+  sudo tee /etc/apt/sources.list.d/ngsoc.list
+sudo apt-get update
+sudo apt-get install bips ng-siem cicms ng-soc
+```
+
+These packages provide the services required by the BIPS, NG‑SIEM, CICMS and NG‑SOC hosts during
+sandbox provisioning.

--- a/sandboxes/provisioning_subcase_1b/site.yml
+++ b/sandboxes/provisioning_subcase_1b/site.yml
@@ -1,4 +1,17 @@
 ---
+- hosts: bips:ng_siem:cicms:ng_soc
+  become: yes
+  vars:
+    ngsoc_repo_url: "https://ngsoc.example.com/apt"
+  tasks:
+    - name: Add NG-SOC APT repository
+      apt_repository:
+        repo: "deb [trusted=yes] {{ ngsoc_repo_url }} stable main"
+        state: present
+    - name: Update apt cache
+      apt:
+        update_cache: yes
+
 - hosts: training_platform
   become: yes
   tasks:


### PR DESCRIPTION
## Summary
- document package locations and container images for BIPS, NG-SIEM, CICMS and NG-SOC
- add playbook tasks to configure a private NG-SOC APT repository

## Testing
- `pip install requests yara`
- `pytest` *(fails: OSError: /root/.pyenv/versions/3.12.10/lib/libyara.so: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f39a2924832d82e8fda6d7c46a35