### PR TITLE
feat: add direct start fallback

### DIFF
--- a/subcase_1c/README.md
+++ b/subcase_1c/README.md
@@ -32,7 +32,7 @@ For a cross-reference of tools, versions, and documentation, see the [NG-SOC com
 5. **Instructor feedback** – Results and lessons learned are submitted back through the RandomSec LMS where instructors review the analysis and provide guidance.
 
 ## Execution Steps
-> **Note:** The startup scripts in this subcase expect `systemctl`. If systemd is unavailable, run them with `DIRECT_START=1` in the environment to use fallback `service` or direct commands.
+> **Note:** The startup scripts in this subcase expect `systemctl`. If systemd is unavailable, run them with `DIRECT_START=1` in the environment. When this flag is set the scripts will try `service` first and, if that is missing, start each component directly.
 1. **Start SOC services**
    ```bash
    sudo subcase_1c/scripts/start_soc_services.sh

--- a/subcase_1c/scripts/start_c2_server.sh
+++ b/subcase_1c/scripts/start_c2_server.sh
@@ -96,12 +96,24 @@ start_c2() {
             return 1
         fi
     else
-        nohup /usr/bin/python3 /opt/c2_server/c2_server.py >>/var/log/c2_server/service.log 2>&1 &
-        sleep 1
-        nc -z localhost "${C2_PORT}" >>/var/log/c2_server/service.log 2>&1 || {
-            echo "$(date) c2_server port check failed" >>/var/log/c2_server/service.log
-            return 1
-        }
+        if command -v service >/dev/null 2>&1; then
+            if service c2_server start >>/var/log/c2_server/service.log 2>&1; then
+                nc -z localhost "${C2_PORT}" >>/var/log/c2_server/service.log 2>&1 || {
+                    echo "$(date) c2_server port check failed" >>/var/log/c2_server/service.log
+                    return 1
+                }
+            else
+                echo "$(date) failed to run service c2_server start" >>/var/log/c2_server/service.log
+                return 1
+            fi
+        else
+            nohup /usr/bin/python3 /opt/c2_server/c2_server.py >>/var/log/c2_server/service.log 2>&1 &
+            sleep 1
+            nc -z localhost "${C2_PORT}" >>/var/log/c2_server/service.log 2>&1 || {
+                echo "$(date) c2_server port check failed" >>/var/log/c2_server/service.log
+                return 1
+            }
+        fi
     fi
 }
 

--- a/subcase_1c/scripts/start_cti_component.sh
+++ b/subcase_1c/scripts/start_cti_component.sh
@@ -82,8 +82,17 @@ start_misp() {
                 return 1
             fi
         else
-            echo "$(date) service command not found" >>/var/log/misp/service.log
-            return 1
+            if command -v misp-server >/dev/null 2>&1; then
+                nohup misp-server >>/var/log/misp/service.log 2>&1 &
+                sleep 1
+                check_port localhost "${MISP_PORT}" >>/var/log/misp/service.log 2>&1 || {
+                    echo "$(date) misp port check failed" >>/var/log/misp/service.log
+                    return 1
+                }
+            else
+                echo "$(date) service command and misp-server not found" >>/var/log/misp/service.log
+                return 1
+            fi
         fi
     fi
 }
@@ -112,8 +121,12 @@ start_fetch_cti_feed() {
                 return 1
             fi
         else
-            echo "$(date) service command not found" >>/var/log/misp/service.log
-            return 1
+            if [ -f /opt/misp/fetch_cti_feed.sh ]; then
+                nohup /opt/misp/fetch_cti_feed.sh >>/var/log/misp/service.log 2>&1 &
+            else
+                echo "$(date) service command and fetch_cti_feed.sh not found" >>/var/log/misp/service.log
+                return 1
+            fi
         fi
     fi
 }

--- a/subcase_1c/scripts/start_soc_services.sh
+++ b/subcase_1c/scripts/start_soc_services.sh
@@ -100,8 +100,19 @@ start_bips() {
                 return 1
             fi
         else
-            echo "$(date) service command not found" >>/var/log/bips/service.log
-            return 1
+            local bips_script
+            bips_script="$(dirname "$0")/bips_start.sh"
+            if [ -x "$bips_script" ]; then
+                bash "$bips_script" >>/var/log/bips/service.log 2>&1 &
+                sleep 1
+                check_port localhost "${BIPS_PORT}" >>/var/log/bips/service.log 2>&1 || {
+                    echo "$(date) bips port check failed" >>/var/log/bips/service.log
+                    return 1
+                }
+            else
+                echo "$(date) service command and bips_start.sh not found" >>/var/log/bips/service.log
+                return 1
+            fi
         fi
     fi
 }
@@ -187,8 +198,17 @@ start_cicms() {
                 return 1
             fi
         else
-            echo "$(date) service command not found" >>/var/log/cicms/service.log
-            return 1
+            if command -v cicms-server >/dev/null 2>&1; then
+                nohup cicms-server --config /etc/cicms/config.yml >>/var/log/cicms/service.log 2>&1 &
+                sleep 1
+                check_port localhost "${CICMS_PORT}" >>/var/log/cicms/service.log 2>&1 || {
+                    echo "$(date) cicms port check failed" >>/var/log/cicms/service.log
+                    return 1
+                }
+            else
+                echo "$(date) service command and cicms-server not found" >>/var/log/cicms/service.log
+                return 1
+            fi
         fi
     fi
 }
@@ -224,8 +244,17 @@ start_ng_soc() {
                 return 1
             fi
         else
-            echo "$(date) service command not found" >>/var/log/ng_soc/service.log
-            return 1
+            if command -v ng-soc >/dev/null 2>&1; then
+                nohup ng-soc --config /etc/ng_soc/config.yml >>/var/log/ng_soc/service.log 2>&1 &
+                sleep 1
+                check_port localhost "${NG_SOC_PORT}" >>/var/log/ng_soc/service.log 2>&1 || {
+                    echo "$(date) ng-soc port check failed" >>/var/log/ng_soc/service.log
+                    return 1
+                }
+            else
+                echo "$(date) service command and ng-soc not found" >>/var/log/ng_soc/service.log
+                return 1
+            fi
         fi
     fi
 }
@@ -261,8 +290,17 @@ start_decide() {
                 return 1
             fi
         else
-            echo "$(date) service command not found" >>/var/log/decide/service.log
-            return 1
+            if [ -f /opt/decide/app.py ]; then
+                nohup /usr/bin/python3 /opt/decide/app.py >>/var/log/decide/service.log 2>&1 &
+                sleep 1
+                check_port localhost "${DECIDE_PORT}" >>/var/log/decide/service.log 2>&1 || {
+                    echo "$(date) decide port check failed" >>/var/log/decide/service.log
+                    return 1
+                }
+            else
+                echo "$(date) service command and /opt/decide/app.py not found" >>/var/log/decide/service.log
+                return 1
+            fi
         fi
     fi
 }
@@ -298,8 +336,17 @@ start_act() {
                 return 1
             fi
         else
-            echo "$(date) service command not found" >>/var/log/act/service.log
-            return 1
+            if [ -f /opt/act/act.py ]; then
+                nohup /usr/bin/python3 /opt/act/act.py >>/var/log/act/service.log 2>&1 &
+                sleep 1
+                check_port localhost "${ACT_PORT}" >>/var/log/act/service.log 2>&1 || {
+                    echo "$(date) act port check failed" >>/var/log/act/service.log
+                    return 1
+                }
+            else
+                echo "$(date) service command and /opt/act/act.py not found" >>/var/log/act/service.log
+                return 1
+            fi
         fi
     fi
 }


### PR DESCRIPTION
## Summary
- add service or direct start modes for SOC services
- add non-systemd startup paths for CTI component and C2 server
- document DIRECT_START behavior

## Testing
- `bash -n subcase_1c/scripts/start_soc_services.sh`
- `bash -n subcase_1c/scripts/start_cti_component.sh`
- `bash -n subcase_1c/scripts/start_c2_server.sh`
- `python subcase_1c/scripts/validate_playbooks.py`

------
https://chatgpt.com/codex/tasks/task_e_68b7f767ee30832d9edd2688cd741bd7