### PR TITLE
feat: require custom credentials and env-based config

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See [deployment manual](docs/deployment_manual.md) for detailed steps including 
 
 ### Phishing Quiz Module
 
-Running `subcase_1b/scripts/training_platform_start.sh` launches a training platform that now includes a phishing-awareness quiz. Once the service is up, the following endpoints can be used to interact with the quiz:
+Running `subcase_1b/scripts/training_platform_start.sh` launches a training platform that now includes a phishing-awareness quiz. Set the `PASSWORD` environment variable to a strong value before starting the service. Once the service is up, the following endpoints can be used to interact with the quiz:
 
 - `GET /quiz/start` – obtain questions.
 - `POST /quiz/submit` – send answers and record the score.

--- a/docs/subcase_1b_guide.md
+++ b/docs/subcase_1b_guide.md
@@ -24,16 +24,19 @@ flowchart TD
 
 1. **Create the Course**
    ```bash
-   sudo subcase_1b/scripts/training_platform_start.sh --course pentest-101
+   export INSTRUCTOR_PASSWORD='S3cureP@ss'
+   sudo PASSWORD="$INSTRUCTOR_PASSWORD" COURSE_NAME=pentest-101 subcase_1b/scripts/training_platform_start.sh
    ```
-   Starts the Flask service, registers the instructor, and creates the course via the REST API.
+   Starts the Flask service, registers the instructor, and creates the course via the REST API. The script
+   refuses to run if `PASSWORD` remains at the insecure default value.
 
    To invite a learner:
    ```bash
-   TOKEN=$(python subcase_1b/training_platform/cli.py login --username instructor --password changeme)
+   TOKEN=$(python subcase_1b/training_platform/cli.py login --username instructor --password "$INSTRUCTOR_PASSWORD")
    COURSE_ID=$(python subcase_1b/training_platform/cli.py list-courses --token "$TOKEN" | python -c 'import sys,json; d=json.load(sys.stdin); print(next(iter(d.keys())))')
    python subcase_1b/training_platform/cli.py invite --token "$TOKEN" --course-id "$COURSE_ID" --email learner@example.com
    ```
+   Set `TRAINING_PLATFORM_URL` if the service runs on a host other than `localhost`.
 2. **Prepare Caldera**
    - Ensure the Caldera server is running and accessible to trainees.
    - Load a demo operation that the `sandcat` agent can execute.
@@ -76,7 +79,9 @@ flowchart TD
 1. Log in to the trainee workstation and retrieve course material from the training platform.
 2. Run the semi-automated scan.
    ```bash
-   sudo subcase_1b/scripts/trainee_start.sh --target 10.10.0.4
+   export TRAINEE_PASSWORD='Str0ngP@ss'
+   export CALDERA_API_KEY='your-caldera-key'
+   sudo PASSWORD="$TRAINEE_PASSWORD" CALDERA_API_KEY="$CALDERA_API_KEY" subcase_1b/scripts/trainee_start.sh --target 10.10.0.4
    ```
    The script sequentially executes the following tools and produces expected deliverables:
    - `nmap` reconnaissance sweep – provides a list of reachable hosts and detected services.

--- a/docs/subcase_1c_guide.md
+++ b/docs/subcase_1c_guide.md
@@ -11,7 +11,8 @@ expected.
 1. **Start SOC services**
 
    ```bash
-   sudo subcase_1c/scripts/start_soc_services.sh
+   export MISP_API_KEY='your-misp-key'
+   sudo MISP_API_KEY="$MISP_API_KEY" subcase_1c/scripts/start_soc_services.sh
    ```
 
    Launches BIPS, NG‑SIEM, CICMS, NG‑SOC, Decide, and Act. Port checks rely on

--- a/subcase_1b/ansible/roles/ng_soc/templates/ng_soc.conf.j2
+++ b/subcase_1b/ansible/roles/ng_soc/templates/ng_soc.conf.j2
@@ -2,4 +2,4 @@
 dashboard: /etc/ng_soc/ngsoc-dashboard.ndjson
 api:
   endpoint: {{ soc_api_endpoint | default('https://soc.internal.local') }}
-  token: {{ soc_api_token | default('changeme') }}
+  token: {{ soc_api_token | default(lookup('env','SOC_API_TOKEN')) }}

--- a/subcase_1b/scripts/trainee_start.sh
+++ b/subcase_1b/scripts/trainee_start.sh
@@ -12,6 +12,16 @@ COURSE_ID="${COURSE_ID:-}"
 CALDERA_SERVER="${CALDERA_SERVER:-http://localhost:8888}"
 CALDERA_API_KEY="${CALDERA_API_KEY:-changeme}"
 
+# fail fast if insecure default credentials are used
+if [ "$PASSWORD" = "changeme" ]; then
+    echo "ERROR: Set PASSWORD to a non-default value before running trainee_start.sh" >&2
+    exit 1
+fi
+if [ "$CALDERA_API_KEY" = "changeme" ]; then
+    echo "ERROR: Set CALDERA_API_KEY to a non-default value before running trainee_start.sh" >&2
+    exit 1
+fi
+
 APT_UPDATED=0
 apt_update_once() {
     if [ "$APT_UPDATED" -eq 0 ]; then

--- a/subcase_1b/scripts/training_platform_start.sh
+++ b/subcase_1b/scripts/training_platform_start.sh
@@ -9,6 +9,12 @@ COURSE_NAME="${COURSE_NAME:-PenTest 101}"
 COURSE_CONTENT="${COURSE_CONTENT:-Introduction to penetration testing}"
 LOG_FILE="${LOG_FILE:-/var/log/training_platform/courses.log}"
 
+# refuse to run with an insecure default instructor password
+if [ "$PASSWORD" = "changeme" ]; then
+    echo "ERROR: Set PASSWORD to a non-default value before starting the training platform." >&2
+    exit 1
+fi
+
 mkdir -p "$(dirname "$LOG_FILE")"
 
 # start service in background

--- a/subcase_1b/training_platform/cli.py
+++ b/subcase_1b/training_platform/cli.py
@@ -1,9 +1,13 @@
 import argparse
 import json
+import os
 import sys
 from urllib import request, parse
 
-BASE_URL = 'http://localhost:5000'
+# Base URL for the training platform API. Can be overridden with the
+# TRAINING_PLATFORM_URL environment variable to point the CLI at a remote
+# service when running inside KYPO.
+BASE_URL = os.environ.get('TRAINING_PLATFORM_URL', 'http://localhost:5000')
 
 
 def post(path, payload):

--- a/subcase_1c/ansible/roles/ng_soc/templates/ng_soc.conf.j2
+++ b/subcase_1c/ansible/roles/ng_soc/templates/ng_soc.conf.j2
@@ -2,4 +2,4 @@
 dashboard: /etc/ng_soc/ngsoc-dashboard.ndjson
 api:
   endpoint: {{ soc_api_endpoint | default('https://soc.internal.local') }}
-  token: {{ soc_api_token | default('changeme') }}
+  token: {{ soc_api_token | default(lookup('env','SOC_API_TOKEN')) }}

--- a/subcase_1c/scripts/start_soc_services.sh
+++ b/subcase_1c/scripts/start_soc_services.sh
@@ -30,6 +30,12 @@ export MISP_API_KEY="${MISP_API_KEY:-changeme}"
 export DECIDE_URL="http://localhost:${DECIDE_PORT}/recommend"
 export ACT_URL="http://localhost:${ACT_PORT}/act"
 
+# ensure the MISP API key is not left at the insecure default
+if [ "$MISP_API_KEY" = "changeme" ]; then
+    echo "ERROR: Set MISP_API_KEY to a non-default value before starting SOC services." >&2
+    exit 1
+fi
+
 {
     echo "$(date) Starting SOC services"
     echo "IRIS_URL=${IRIS_URL}"


### PR DESCRIPTION
## Summary
- use TRAINING_PLATFORM_URL env var in CLI
- add safeguards against default credentials in startup scripts
- document required env vars for instructor, trainee, and MISP API key

## Testing
- `bash -n subcase_1b/scripts/training_platform_start.sh`
- `bash -n subcase_1b/scripts/trainee_start.sh`
- `bash -n subcase_1c/scripts/start_soc_services.sh`
- `python -m py_compile subcase_1b/training_platform/cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7f88487a0832dae666a471819cd4b