### PR TITLE
Add requirements files and update deployment docs

### DIFF
--- a/docs/deployment_manual.md
+++ b/docs/deployment_manual.md
@@ -31,10 +31,15 @@ This manual describes how to deploy KYPO training scenarios in this repository. 
 ## Service Orchestration
 
 1. **Provision VMs** – Start VMs from the prepared images or snapshots and verify connectivity.
-2. **Launch core services**
+2. **Install Python dependencies** – Before running any scenario scripts, install required packages:
+   ```bash
+   pip install -r subcase_1b/training_platform/requirements.txt   # for Subcase 1b
+   pip install -r subcase_1c/requirements.txt                     # for Subcase 1c
+   ```
+3. **Launch core services**
    - Start BIPS, NG‑SIEM, CICMS, NG‑SOC, and related components using the scripts under `subcase_1b/scripts/` or `subcase_1c/scripts/`.
    - If `systemctl` is unavailable, set `DIRECT_START=1` to invoke legacy service scripts.
-3. **Validate operation**
+4. **Validate operation**
    - Confirm ports are listening and dashboards are reachable.
    - Run the scenario‑specific validation steps from the respective guide.
 

--- a/docs/subcase_1b_guide.md
+++ b/docs/subcase_1b_guide.md
@@ -22,7 +22,11 @@ flowchart TD
 
 ## Instructor Setup
 
-1. **Create the Course**
+1. **Install dependencies**
+   ```bash
+   pip install -r subcase_1b/training_platform/requirements.txt
+   ```
+2. **Create the Course**
    ```bash
    export INSTRUCTOR_PASSWORD='S3cureP@ss'
    sudo PASSWORD="$INSTRUCTOR_PASSWORD" COURSE_NAME=pentest-101 subcase_1b/scripts/training_platform_start.sh
@@ -37,10 +41,10 @@ flowchart TD
    python subcase_1b/training_platform/cli.py invite --token "$TOKEN" --course-id "$COURSE_ID" --email learner@example.com
    ```
    Set `TRAINING_PLATFORM_URL` if the service runs on a host other than `localhost`.
-2. **Prepare Caldera**
+3. **Prepare Caldera**
    - Ensure the Caldera server is running and accessible to trainees.
    - Load a demo operation that the `sandcat` agent can execute.
-3. **Start the Cyber Range and Security Pipeline**
+4. **Start the Cyber Range and Security Pipeline**
    - Cyber Range
      ```bash
      sudo subcase_1b/scripts/cyber_range_start.sh
@@ -69,7 +73,7 @@ flowchart TD
      sudo subcase_1b/scripts/ng_soc_start.sh
      ```
    - Analysts monitoring these services can follow the [SOC Analyst Playbook](soc_analyst_playbook.md) for dashboard navigation, search queries, and alert confirmation criteria.
-4. **Evaluation**
+5. **Evaluation**
    - Review trainee scan logs and submitted vulnerability reports.
    - Confirm Caldera operations completed successfully.
    - Provide feedback through the training platform.

--- a/docs/subcase_1c_guide.md
+++ b/docs/subcase_1c_guide.md
@@ -8,7 +8,11 @@ expected.
 
 ## Deployment
 
-1. **Start SOC services**
+1. **Install dependencies**
+   ```bash
+   pip install -r subcase_1c/requirements.txt
+   ```
+2. **Start SOC services**
 
    ```bash
    export MISP_API_KEY='your-misp-key'
@@ -18,7 +22,7 @@ expected.
    Launches BIPS, NG‑SIEM, CICMS, NG‑SOC, Decide, and Act. Port checks rely on
    Bash's `/dev/tcp` and `timeout` rather than external utilities.
 
-2. **Start CTI component and ingest feeds**
+3. **Start CTI component and ingest feeds**
 
    ```bash
    sudo subcase_1c/scripts/start_cti_component.sh
@@ -28,13 +32,13 @@ expected.
    NG‑SIEM. Use `CTI_OFFLINE=1` or run the fetch script with `--offline` to
    skip external downloads when network access is unavailable.
 
-3. **Launch the C2 server**
+4. **Launch the C2 server**
 
    ```bash
    sudo subcase_1c/scripts/start_c2_server.sh
    ```
 
-4. **Configure malware detection rules**
+5. **Configure malware detection rules**
 
    YARA rules live in `subcase_1c/malware_detection/rules/`. Add or adjust
    rules in this directory and scan samples with:
@@ -43,7 +47,7 @@ expected.
    python subcase_1c/malware_detection/scanner.py <sample>
    ```
 
-5. **Validate playbooks**
+6. **Validate playbooks**
 
    Act consumes CACAO‑style playbooks from `subcase_1c/playbooks/` for actions
    such as host isolation or malware eradication. Validate the playbooks

--- a/subcase_1b/training_platform/requirements.txt
+++ b/subcase_1b/training_platform/requirements.txt
@@ -1,0 +1,5 @@
+Flask
+requests
+PyJWT
+Jinja2
+PyYAML

--- a/subcase_1c/requirements.txt
+++ b/subcase_1c/requirements.txt
@@ -1,0 +1,6 @@
+Flask
+requests
+numpy
+scikit-learn
+PyYAML
+Jinja2


### PR DESCRIPTION
## Summary
- Add Python dependency lists for subcase_1b training platform and subcase_1c
- Document `pip install -r requirements.txt` step in deployment guides
- Note dependency installation in overall deployment manual

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7fc2eaf9c832d800e092cddeb798d