### PR TITLE
feat: support offline package installation

### DIFF
--- a/docs/deployment_manual.md
+++ b/docs/deployment_manual.md
@@ -28,6 +28,19 @@ This manual describes how to deploy KYPO training scenarios in this repository. 
    - Create service accounts and SSH keys as required.
 3. **Snapshot** – Take a snapshot of each VM after configuration so it can be restored for future exercises.
 
+## Offline Environments
+
+For systems without Internet access, pre-download required packages and modules:
+
+- Copy any necessary `.deb` files to `/opt/offline`. The start scripts for Subcase 1c
+  (e.g., `start_soc_services.sh` and `start_cti_component.sh`) will install packages
+  from this directory if `apt-get` fails.
+- Save PowerShell modules for offline use:
+  ```powershell
+  Save-Module -Name PowerShellGet,PackageManagement -Path /opt/offline/psmodules
+  ```
+- Ensure these paths are available on the target machines before running the scenario scripts.
+
 ## Service Orchestration
 
 1. **Provision VMs** – Start VMs from the prepared images or snapshots and verify connectivity.

--- a/subcase_1c/scripts/load_malware_simulation.ps1
+++ b/subcase_1c/scripts/load_malware_simulation.ps1
@@ -4,14 +4,28 @@ param(
     [string]$Controller = "localhost"
 )
 
+# To prepare for offline use, predownload required modules:
+#   Save-Module -Name PowerShellGet,PackageManagement -Path /opt/offline/psmodules
+# The script will try to install modules from this location if online installation fails.
+
+$offlineModulePath = "/opt/offline/psmodules"
 Write-Host "Installing required modules..."
 try {
     if (-not (Get-Command Invoke-WebRequest -ErrorAction SilentlyContinue)) {
-        Install-PackageProvider -Name NuGet -Force | Out-Null
-        Install-Module -Name PowerShellGet -Force | Out-Null
+        Install-PackageProvider -Name NuGet -Force -ErrorAction Stop | Out-Null
+        Install-Module -Name PowerShellGet -Force -ErrorAction Stop | Out-Null
     }
 } catch {
-    Write-Warning "Failed to install PowerShell modules: $_"
+    Write-Warning "Failed to install PowerShell modules online: $_"
+    if (Test-Path $offlineModulePath) {
+        Write-Host "Attempting to load modules from $offlineModulePath"
+        try {
+            Import-Module (Join-Path $offlineModulePath 'PackageManagement') -Force -ErrorAction Stop
+            Import-Module (Join-Path $offlineModulePath 'PowerShellGet') -Force -ErrorAction Stop
+        } catch {
+            Write-Error "Failed to load modules from offline cache: $_"
+        }
+    }
 }
 
 if (Test-Path $SimulationScript) {

--- a/subcase_1c/scripts/start_cti_component.sh
+++ b/subcase_1c/scripts/start_cti_component.sh
@@ -38,11 +38,19 @@ install_deps() {
     fi
 
     if ! command -v timeout >/dev/null 2>&1; then
-        apt_update_once || return 1
+        apt_update_once || true
         export DEBIAN_FRONTEND=noninteractive
         if ! apt-get install -y coreutils; then
-            echo "$(date) failed to install coreutils" >&2
-            return 1
+            echo "$(date) failed to install coreutils via apt-get; trying local packages" >&2
+            if ls /opt/offline/*.deb >/dev/null 2>&1; then
+                if ! dpkg -i /opt/offline/*.deb; then
+                    echo "$(date) failed to install local packages from /opt/offline" >&2
+                    return 1
+                fi
+            else
+                echo "$(date) no local packages found in /opt/offline" >&2
+                return 1
+            fi
         fi
     fi
 }

--- a/subcase_1c/scripts/start_soc_services.sh
+++ b/subcase_1c/scripts/start_soc_services.sh
@@ -67,11 +67,19 @@ install_deps() {
     fi
 
     if ! command -v timeout >/dev/null 2>&1; then
-        apt_update_once || return 1
+        apt_update_once || true
         export DEBIAN_FRONTEND=noninteractive
         if ! apt-get install -y coreutils; then
-            echo "$(date) failed to install coreutils" >&2
-            return 1
+            echo "$(date) failed to install coreutils via apt-get; trying local packages" >&2
+            if ls /opt/offline/*.deb >/dev/null 2>&1; then
+                if ! dpkg -i /opt/offline/*.deb; then
+                    echo "$(date) failed to install local packages from /opt/offline" >&2
+                    return 1
+                fi
+            else
+                echo "$(date) no local packages found in /opt/offline" >&2
+                return 1
+            fi
         fi
     fi
 }


### PR DESCRIPTION
## Summary
- fallback to local .deb packages when apt-get fails
- search offline PowerShell modules when online install fails
- document offline deployments and package cache

## Testing
- `bash -n subcase_1c/scripts/start_soc_services.sh`
- `bash -n subcase_1c/scripts/start_cti_component.sh`
- `shellcheck subcase_1c/scripts/start_soc_services.sh` *(fails: command not found)*
- `pwsh -NoLogo -NoProfile -Command "Test-ModuleManifest" 2>&1 | head -n 2` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b7fdc68da8832d98a6403036f7241f