### PR TITLE
Add yara-python dependency for subcase 1c

### DIFF
--- a/docs/deployment_manual.md
+++ b/docs/deployment_manual.md
@@ -49,6 +49,8 @@ For systems without Internet access, pre-download required packages and modules:
    pip install -r subcase_1b/training_platform/requirements.txt   # for Subcase 1b
    pip install -r subcase_1c/requirements.txt                     # for Subcase 1c
    ```
+   The Subcase 1c requirements include the `yara-python` library to enable
+   rule-based malware detection.
 3. **Launch core services**
    - Start BIPS, NG‑SIEM, CICMS, NG‑SOC, and related components using the scripts under `subcase_1b/scripts/` or `subcase_1c/scripts/`.
    - If `systemctl` is unavailable, set `DIRECT_START=1` to invoke legacy service scripts.

--- a/docs/subcase_1c_guide.md
+++ b/docs/subcase_1c_guide.md
@@ -46,6 +46,8 @@ expected.
    ```bash
    python subcase_1c/malware_detection/scanner.py <sample>
    ```
+   The scanner depends on the `yara-python` library provided in the
+   Subcase 1c requirements file.
 
 6. **Validate playbooks**
 

--- a/subcase_1c/requirements.txt
+++ b/subcase_1c/requirements.txt
@@ -4,3 +4,4 @@ numpy
 scikit-learn
 PyYAML
 Jinja2
+yara-python


### PR DESCRIPTION
## Summary
- add yara-python to Subcase 1c Python requirements
- mention yara-python in the deployment manual and Subcase 1c guide

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7ff6ddd58832d9fc4e63f6f733216