### PR TITLE
Add IRIS case fields and template

### DIFF
--- a/subcase_1c/act/templates/iris_case.json
+++ b/subcase_1c/act/templates/iris_case.json
@@ -1,0 +1,10 @@
+{
+  "title": "Automated Incident",
+  "description": "Template for IRIS case created by the IDS ML pipeline.",
+  "signature": "",
+  "src_ip": "",
+  "dest_ip": "",
+  "entry_point": "",
+  "propagation_method": "",
+  "improvements": ""
+}

--- a/subcase_1c/bips/ids_ml.py
+++ b/subcase_1c/bips/ids_ml.py
@@ -138,6 +138,9 @@ def create_case(event: dict) -> None:
         "signature": event.get("alert", {}).get("signature"),
         "src_ip": event.get("src_ip"),
         "dest_ip": event.get("dest_ip"),
+        "entry_point": event.get("entry_point"),
+        "propagation_method": event.get("propagation_method"),
+        "improvements": event.get("improvements"),
     }
     try:
         requests.post(IRIS_URL, json=payload, timeout=5)


### PR DESCRIPTION
## Summary
- capture entry point, propagation method, and improvements when creating IRIS cases
- add IRIS case template for ACT to bootstrap case creation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b844555238832d9dc94992717a827f