### PR TITLE
feat: sync misp and push enrichment

### DIFF
--- a/subcase_1c/ansible/roles/misp/defaults/main.yml
+++ b/subcase_1c/ansible/roles/misp/defaults/main.yml
@@ -2,3 +2,9 @@
 # Base URL for NG-SOAR package repository. Override in inventory or group vars.
 ngsoar_repo_url: "https://packages.internal.example.com"
 misp_agent_checksum: "sha256:880dab7c445872663d4dd4326bf6b0c49337b467ae03247c092cdf052116fdaa"
+
+# Remote MISP synchronisation settings and IRIS webhook endpoint
+remote_misp_url: "https://misp.remote.local"
+remote_misp_key: "changeme"
+iris_webhook_url: "http://localhost:5800/iocs"
+misp_webhook_port: 9000

--- a/subcase_1c/ansible/roles/misp/tasks/main.yml
+++ b/subcase_1c/ansible/roles/misp/tasks/main.yml
@@ -87,3 +87,56 @@
     enabled: yes
     daemon_reload: yes
   become: yes
+
+# Synchronise with remote MISP and expose webhook for IRIS
+- name: Deploy MISP sync script
+  ansible.builtin.template:
+    src: misp-sync.sh.j2
+    dest: /opt/misp/misp-sync.sh
+    owner: root
+    group: root
+    mode: "0755"
+  become: yes
+
+- name: Install misp-sync service
+  ansible.builtin.template:
+    src: misp-sync.service.j2
+    dest: /etc/systemd/system/misp-sync.service
+    owner: root
+    group: root
+    mode: "0644"
+  become: yes
+
+- name: Enable and start misp-sync service
+  ansible.builtin.service:
+    name: misp-sync
+    state: started
+    enabled: yes
+    daemon_reload: yes
+  become: yes
+
+- name: Deploy IRIS webhook script
+  ansible.builtin.template:
+    src: iris_webhook.py.j2
+    dest: /opt/misp/iris_webhook.py
+    owner: root
+    group: root
+    mode: "0755"
+  become: yes
+
+- name: Install iris-webhook service
+  ansible.builtin.template:
+    src: iris-webhook.service.j2
+    dest: /etc/systemd/system/iris-webhook.service
+    owner: root
+    group: root
+    mode: "0644"
+  become: yes
+
+- name: Enable and start iris-webhook service
+  ansible.builtin.service:
+    name: iris-webhook
+    state: started
+    enabled: yes
+    daemon_reload: yes
+  become: yes

--- a/subcase_1c/ansible/roles/misp/templates/iris-webhook.service.j2
+++ b/subcase_1c/ansible/roles/misp/templates/iris-webhook.service.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=Forward MISP webhook data to IRIS
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python3 /opt/misp/iris_webhook.py
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/subcase_1c/ansible/roles/misp/templates/iris_webhook.py.j2
+++ b/subcase_1c/ansible/roles/misp/templates/iris_webhook.py.j2
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import requests
+
+IRIS_URL = "{{ iris_webhook_url }}"
+PORT = {{ misp_webhook_port }}
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get('Content-Length', 0))
+        data = self.rfile.read(length)
+        try:
+            requests.post(IRIS_URL, data=data, timeout=5)
+            self.send_response(200)
+        except Exception:  # noqa: BLE001
+            self.send_response(500)
+        self.end_headers()
+
+if __name__ == "__main__":
+    HTTPServer(("", PORT), Handler).serve_forever()

--- a/subcase_1c/ansible/roles/misp/templates/misp-sync.service.j2
+++ b/subcase_1c/ansible/roles/misp/templates/misp-sync.service.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=MISP remote sync service
+
+[Service]
+Type=simple
+Environment="MISP_REMOTE_URL={{ remote_misp_url }}" "MISP_REMOTE_KEY={{ remote_misp_key }}"
+ExecStart=/opt/misp/misp-sync.sh
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/subcase_1c/ansible/roles/misp/templates/misp-sync.sh.j2
+++ b/subcase_1c/ansible/roles/misp/templates/misp-sync.sh.j2
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -euo pipefail
+misp-cli sync "$MISP_REMOTE_URL" "$MISP_REMOTE_KEY"

--- a/subcase_1c/ansible/roles/misp/templates/misp.conf.j2
+++ b/subcase_1c/ansible/roles/misp/templates/misp.conf.j2
@@ -5,3 +5,10 @@ simulation:
 logging:
   directory: /var/log/misp
   level: INFO
+
+sync:
+  url: {{ remote_misp_url }}
+  api_key: {{ remote_misp_key }}
+
+webhook:
+  url: {{ iris_webhook_url }}


### PR DESCRIPTION
## Summary
- configure MISP role to sync with remote instance and forward enriched IoCs to IRIS via webhook
- extend ids_ml to annotate IRIS cases with MISP context and notify NG-SOAR

## Testing
- `python -m py_compile subcase_1c/bips/ids_ml.py`
- `pytest`
- `ansible-playbook subcase_1c/ansible/playbook.yml --syntax-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b844ff0b80832da3a929f4034e816b