### PR TITLE
Automate post-incident reporting and MISP tagging on IRIS case closure

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,26 @@ Sample lessons and a quiz are provided under `open_edx/course`. To load this mat
 2. In Studio, open the target course and navigate to **Tools → Import**.
 3. Upload `phishing_course.zip` to add the lessons and quiz.
 
+### IRIS Case Closure Automation
+
+The repository includes `scripts/iris_case_closed_poll.py`, a helper that
+polls an IRIS case-management instance for cases marked as **closed**. When a
+newly closed case is discovered it will:
+
+1. Run `subcase_1c/scripts/generate_post_incident_report.sh` to create a
+   post-incident report.
+2. Tag the associated MISP event with `lessons learned` via the MISP API.
+
+Configuration is handled through environment variables such as `IRIS_URL`,
+`IRIS_API_KEY`, `MISP_URL`, and `MISP_API_KEY`. Execute the script with:
+
+```bash
+python scripts/iris_case_closed_poll.py
+```
+
+The script keeps track of processed case IDs in `scripts/.iris_processed_cases.json`
+to avoid duplicate reports.
+
 ## Teardown
 
 1. Stop the scenario from the KYPO dashboard.

--- a/scripts/iris_case_closed_poll.py
+++ b/scripts/iris_case_closed_poll.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Poll the IRIS API for closed cases and generate post-incident reports.
+
+This script periodically queries the IRIS case management API for cases
+whose status is "closed". When a new closed case is found, it runs the
+``generate_post_incident_report.sh`` helper and then tags the related MISP
+event with ``lessons learned``.
+
+Configuration is handled via environment variables:
+
+``IRIS_URL``            Base URL of the IRIS API (default: http://localhost:8000/api)
+``IRIS_API_KEY``        API key for IRIS authentication (optional)
+``MISP_URL``            Base URL of the MISP instance (default: http://localhost:8080)
+``MISP_API_KEY``        API key for MISP authentication (required for tagging)
+``REPORT_SCRIPT``       Path to ``generate_post_incident_report.sh``
+                        (default: ../subcase_1c/scripts/generate_post_incident_report.sh)
+``POLL_INTERVAL``       Seconds between checks (default: 60)
+``STATE_FILE``          File tracking processed case IDs
+                        (default: scripts/.iris_processed_cases.json)
+
+The script stores a JSON list of case IDs it has already handled to avoid
+re-running the report for the same case.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+from typing import Iterable, Set
+
+import requests
+
+IRIS_URL = os.getenv("IRIS_URL", "http://localhost:8000/api")
+IRIS_API_KEY = os.getenv("IRIS_API_KEY")
+MISP_URL = os.getenv("MISP_URL", "http://localhost:8080")
+MISP_API_KEY = os.getenv("MISP_API_KEY")
+REPORT_SCRIPT = os.getenv(
+    "REPORT_SCRIPT",
+    str(Path(__file__).resolve().parents[1] / "subcase_1c" / "scripts" / "generate_post_incident_report.sh"),
+)
+POLL_INTERVAL = int(os.getenv("POLL_INTERVAL", "60"))
+STATE_FILE = Path(os.getenv("STATE_FILE", Path(__file__).with_name(".iris_processed_cases.json")))
+
+
+def load_processed() -> Set[str]:
+    if STATE_FILE.exists():
+        try:
+            return set(json.loads(STATE_FILE.read_text()))
+        except Exception:
+            return set()
+    return set()
+
+
+def save_processed(case_ids: Iterable[str]) -> None:
+    STATE_FILE.write_text(json.dumps(list(case_ids)))
+
+
+def fetch_closed_cases() -> Iterable[dict]:
+    headers = {"Authorization": IRIS_API_KEY} if IRIS_API_KEY else {}
+    resp = requests.get(f"{IRIS_URL}/cases", params={"status": "closed"}, headers=headers, timeout=30)
+    resp.raise_for_status()
+    data = resp.json()
+    # Assume API returns a list of case objects
+    return data
+
+
+def run_report() -> None:
+    subprocess.run([REPORT_SCRIPT], check=True)
+
+
+def tag_misp_event(event_id: str) -> None:
+    if not MISP_API_KEY:
+        raise RuntimeError("MISP_API_KEY is not set; cannot tag event")
+    headers = {
+        "Authorization": MISP_API_KEY,
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+    payload = {"tag": "lessons learned"}
+    resp = requests.post(
+        f"{MISP_URL}/events/{event_id}/tags/add",
+        headers=headers,
+        json=payload,
+        timeout=30,
+        verify=False,
+    )
+    resp.raise_for_status()
+
+
+def main() -> None:
+    processed = load_processed()
+    while True:
+        try:
+            for case in fetch_closed_cases():
+                case_id = str(case.get("id"))
+                if case_id in processed:
+                    continue
+                run_report()
+                event_id = case.get("misp_event_id")
+                if event_id:
+                    try:
+                        tag_misp_event(str(event_id))
+                    except Exception as exc:  # pragma: no cover - logging only
+                        print(f"Failed to tag MISP event {event_id}: {exc}")
+                processed.add(case_id)
+                save_processed(processed)
+        except Exception as exc:  # pragma: no cover - logging only
+            print(f"Error while polling IRIS: {exc}")
+        time.sleep(POLL_INTERVAL)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add polling utility to monitor IRIS for closed cases, generate post-incident reports, and tag related MISP events with `lessons learned`
- Document IRIS case closure automation workflow in README

## Testing
- `python -m py_compile scripts/iris_case_closed_poll.py`


------
https://chatgpt.com/codex/tasks/task_e_68b84887d0c4832d9bdefbdc4937839d