### PR TITLE
feat: push grades to Open edX

### DIFF
--- a/docs/env_variables.md
+++ b/docs/env_variables.md
@@ -8,6 +8,8 @@ Certain scripts in this repository rely on environment variables for authenticat
 | `OPENEDX_URL` | Base URL of the Open edX instance (default `http://localhost:8000`). |
 | `OPENEDX_SESSION_COOKIE` | Session cookie for Open edX API calls. Optional when using an API token. |
 | `OPENEDX_API_TOKEN` | Token granting access to the Open edX REST API. |
+| `OPENEDX_GRADEBOOK_ENDPOINT` | URL template used to push grades to the Open edX gradebook. |
+| `OPENEDX_GRADEBOOK_TOKEN` | Token used for gradebook API requests. Defaults to `OPENEDX_API_TOKEN`. |
 | `KYPO_URL` | Base URL of the KYPO LTI provider (default `http://localhost:5000`). |
 | `LTI_CLIENT_ID` | Client identifier issued by KYPO for the LTI integration. |
 | `LTI_DEPLOYMENT_ID` | Deployment identifier for the LTI consumer. |

--- a/docs/subcase_1b_guide.md
+++ b/docs/subcase_1b_guide.md
@@ -160,6 +160,17 @@ curl -X POST http://localhost:5000/results \
 The recorded metrics allow instructors to review completion times and
 quiz performance when assessing learner progress.
 
+To also record grades in the Open edX gradebook, export the following
+environment variables so the training platform can reach the REST API:
+
+```bash
+export OPENEDX_GRADEBOOK_ENDPOINT='https://openedx.example/api/grades/v1/course_grade/{course_id}/{username}'
+export OPENEDX_GRADEBOOK_TOKEN='your-gradebook-token'
+```
+
+The endpoint can include the placeholders ``{course_id}`` and
+``{username}`` which are replaced at runtime.
+
 ## KYPO Lab Integration
 
 The training platform can launch [KYPO](https://www.kypo.muni.cz/) labs


### PR DESCRIPTION
## Summary
- add `push_grade_lms` to send grades to Open edX via REST API
- report quiz scores to Open edX and track failures
- document gradebook endpoint and token environment variables

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b85376c92c832dac0bee7d499b00f2