### PR TITLE
Initialize MISP sharing policy with local group and TLP taxonomy

### DIFF
--- a/docs/subcase_1c_guide.md
+++ b/docs/subcase_1c_guide.md
@@ -59,6 +59,14 @@ expected.
    python subcase_1c/scripts/validate_playbooks.py
    ```
 
+### Sharing policy
+
+`start_cti_component.sh` initializes a local sharing policy for MISP. A
+*Local sharing group* limits dissemination to internal participants, and the
+`TLP` taxonomy is imported and enabled so that indicators can be tagged with
+traffic-light protocol markings. This ensures threat intelligence is scoped to
+the local environment and classified consistently.
+
 ## IRIS Incident Flow States
 
 The case management system tracks three primary response phases:

--- a/subcase_1c/misp/sharing_setup.py
+++ b/subcase_1c/misp/sharing_setup.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Initial MISP sharing configuration for Subcase 1c.
+
+Creates a local sharing group and enables the TLP taxonomy.
+The script is idempotent; failures are logged to stderr but do not
+halt execution when the group or taxonomy already exist.
+"""
+import json
+import os
+import sys
+from typing import Any
+
+import requests
+
+MISP_URL = os.getenv("MISP_URL", "http://localhost:8443")
+MISP_API_KEY = os.getenv("MISP_API_KEY")
+
+if not MISP_API_KEY:
+    print("MISP_API_KEY is not set; aborting sharing setup", file=sys.stderr)
+    sys.exit(1)
+
+HEADERS = {
+    "Authorization": MISP_API_KEY,
+    "Accept": "application/json",
+    "Content-Type": "application/json",
+}
+
+session = requests.Session()
+session.verify = False  # local demo environment
+
+
+def _post(path: str, payload: Any | None = None) -> requests.Response:
+    url = f"{MISP_URL.rstrip('/')}/{path.lstrip('/')}"
+    return session.post(url, headers=HEADERS, json=payload, timeout=10)
+
+
+def create_local_group() -> None:
+    """Create a local sharing group in MISP."""
+    group = {
+        "name": "Local sharing group",
+        "releasability": "Internal",
+        "description": "Local sharing group for Subcase 1c",
+        "local": True,
+    }
+    try:
+        resp = _post("/sharing_groups/add", group)
+        if resp.status_code == 200:
+            print("Local sharing group created or already exists.")
+        else:
+            print(f"Failed to create sharing group: {resp.status_code} {resp.text}", file=sys.stderr)
+    except requests.RequestException as exc:
+        print(f"Error creating sharing group: {exc}", file=sys.stderr)
+
+
+def enable_tlp_taxonomy() -> None:
+    """Import and enable the TLP taxonomy."""
+    for action in ("import", "enable"):
+        try:
+            resp = _post(f"/taxonomies/{action}/tlp")
+            if resp.status_code == 200:
+                print(f"TLP taxonomy {action}ed.")
+            else:
+                print(
+                    f"Failed to {action} TLP taxonomy: {resp.status_code} {resp.text}",
+                    file=sys.stderr,
+                )
+        except requests.RequestException as exc:
+            print(f"Error during taxonomy {action}: {exc}", file=sys.stderr)
+
+
+def main() -> None:
+    create_local_group()
+    enable_tlp_taxonomy()
+
+
+if __name__ == "__main__":
+    main()

--- a/subcase_1c/scripts/start_cti_component.sh
+++ b/subcase_1c/scripts/start_cti_component.sh
@@ -105,6 +105,20 @@ start_misp() {
     fi
 }
 
+run_sharing_setup() {
+    # configure MISP sharing settings
+    mkdir -p /var/log/misp
+    local script="$(dirname "$0")/../misp/sharing_setup.py"
+    if [ -f "$script" ]; then
+        if command -v python3 >/dev/null 2>&1; then
+            python3 "$script" >>/var/log/misp/service.log 2>&1 || \
+                echo "$(date) sharing setup failed" >>/var/log/misp/service.log
+        else
+            echo "$(date) python3 not found; skipping sharing setup" >>/var/log/misp/service.log
+        fi
+    fi
+}
+
 start_fetch_cti_feed() {
     mkdir -p /var/log/misp
     if [ "$USE_SYSTEMCTL" -eq 1 ]; then
@@ -141,4 +155,5 @@ start_fetch_cti_feed() {
 
 install_deps
 start_misp
+run_sharing_setup
 start_fetch_cti_feed


### PR DESCRIPTION
## Summary
- add script to create a local MISP sharing group and enable the TLP taxonomy
- run sharing setup automatically from `start_cti_component.sh`
- document local sharing policy in Subcase 1c guide

## Testing
- `pytest subcase_1c/malware_detection/tests/test_scanner.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8595c5654832db125492310cd7b8e