### PR TITLE
feat: secure mongo deployment

### DIFF
--- a/docs/subcase_1c_guide.md
+++ b/docs/subcase_1c_guide.md
@@ -16,11 +16,17 @@ expected.
 
    ```bash
    export MISP_API_KEY='your-misp-key'
-   sudo MISP_API_KEY="$MISP_API_KEY" subcase_1c/scripts/start_soc_services.sh
-   ```
+    sudo MISP_API_KEY="$MISP_API_KEY" subcase_1c/scripts/start_soc_services.sh
+    ```
 
-   Launches BIPS, NG‑SIEM, CICMS, NG‑SOAR, Decide, and Act. Port checks rely on
-   Bash's `/dev/tcp` and `timeout` rather than external utilities.
+    Launches BIPS, NG‑SIEM, CICMS, NG‑SOAR, Decide, and Act. Port checks rely on
+    Bash's `/dev/tcp` and `timeout` rather than external utilities.
+
+    The MongoDB instance starts with the admin user `soc_admin` and password
+    `soc_password` (override with `MONGO_INITDB_ROOT_USERNAME` and
+    `MONGO_INITDB_ROOT_PASSWORD`). Data is persisted to the `cacao-mongo-data`
+    Docker volume, and the `oplogMinRetentionHours` setting in
+    `subcase_1c/mongod.conf` keeps change history for seven days.
 
 3. **Start CTI component and ingest feeds**
 

--- a/subcase_1c/mongod.conf
+++ b/subcase_1c/mongod.conf
@@ -1,0 +1,13 @@
+storage:
+  dbPath: /data/db
+
+systemLog:
+  destination: file
+  path: /var/log/mongodb/mongod.log
+  logAppend: true
+
+net:
+  bindIpAll: true
+
+replication:
+  oplogMinRetentionHours: 168


### PR DESCRIPTION
## Summary
- create Mongo admin user and password via environment variables
- persist MongoDB data volume and apply retention config
- document credentials and retention policy for Subcase 1c

## Testing
- `bash -n subcase_1c/scripts/start_soc_services.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b85ad58e1c832da0ebbe748a90e374